### PR TITLE
Set correct publicUrl

### DIFF
--- a/config/production.js
+++ b/config/production.js
@@ -9,7 +9,7 @@ module.exports = {
     allowedRegions:       'us-west-1,us-west-2,us-east-1', // comma seperated list
   },
   server: {
-    publicUrl:  'https://aws-provisioner2.herokuapp.com',
+    publicUrl:  'https://taskcluster-aws-provisioner2.herokuapp.com',
     port:       5557,
     env:        'production',
     forceSSL:   true,


### PR DESCRIPTION
Eventually, this should live under `aws-provisioner.taskcluster.net` but this is okay for now...
However, we really should set right baseUrl.