### PR TITLE
add and test an api end point to track when a worker comes online

### DIFF
--- a/provisioner/influx-series.js
+++ b/provisioner/influx-series.js
@@ -139,3 +139,15 @@ module.exports.provisionerIteration = new base.stats.Series({
     change: base.stats.types.Number,
   },
 });
+
+module.exports.workerTypeCheckIn = new base.stats.Series({
+  name: 'AwsProvisioner.WorkerTypeCheckIn',
+  columns: {
+    instanceId: base.stats.types.String,
+    requestId: base.stats.types.String,
+    region: base.stats.types.String,
+    az: base.stats.types.String,
+    instanceType: base.stats.types.String,
+    workerType: base.stats.types.String,
+  }
+});

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -304,6 +304,50 @@ api.declare({
   return p;
 });
 
+
+
+
+api.declare({
+  method: 'put',
+  route: '/check-in/:workerType',
+  name: 'workerCheckIn',
+  deferAuth: true,
+  scopes: ['aws-provisioner:check-in:<workerType>'],
+  input: SCHEMA_PREFIX_CONST + 'worker-type-check-in-request.json#',
+  title: 'Check-in for a workerType',
+  description: [
+    'Check in for a worker type',
+    '',
+    '*** EXPERIMENTAL ***',
+  ].join('\n'),
+}, async function (req, res) {
+  var input = req.body;
+  var workerType = req.params.workerType;
+
+  // Authenticate request with parameterized scope
+  if (!req.satisfies({workerType: workerType})) {
+    return;
+  }
+
+  // TODO:
+  // add series require() call to bin/server.js
+  // pass that through to here as context
+  // create a reporter there.
+
+  this.reportWorkerTypeCheckIn({
+    instanceId: input.instanceId,
+    requestId: input.requestId || '',
+    region: input.region,
+    az: input.az,
+    instanceType: input.instanceType,
+    workerType: workerType,
+  });
+
+  res.reply({outcome: 'success'});
+  return;
+});
+
+
 api.declare({
   method: 'get',
   route: '/list-worker-types',

--- a/test/helper.js
+++ b/test/helper.js
@@ -53,7 +53,9 @@ mocha.before(async () => {
     clients: defaultClients,
   });
 
-  webServer = await bin.server('test');
+  webServer = await bin.server('test', true);
+  // Ugh, again pretty ugly
+  exports.influx = bin.server.influx;
 
   // Create client for working with API
   exports.baseUrl = 'http://localhost:' + webServer.address().port + '/v1';

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -99,6 +99,29 @@ describe('provisioner api server', function () {
     });
   });
 
+  describe('worker type checkin', function () {
+    it('should be able to check in a worker type', function() {
+      var testData = {
+        instanceId: 'i-abcde1234',
+        requestId: 'sir-abcde3123',
+        region: 'us-west-2',
+        az: 'us-west-2b',
+        instanceType: 'r3.xlarge',
+      };
+
+      subject.influx.pendingPoints().should.equal(0);
+      var p = subject.awsProvisioner.workerCheckIn('test', testData); 
+
+      p.then(function(x) {
+        return subject.influx.close().then(function() {
+          subject.influx.pendingPoints().should.equal(1);
+        });
+      });
+
+      return p;
+    });
+  });
+
   describe('listing worker types', function () {
     it('should return a list', function () {
       var p = subject.awsProvisioner.listWorkerTypes();


### PR DESCRIPTION
Quick endpoint with a test for checking in a workerType.  I don't know that we'll ever use it in production, but having it available is part of my Q2 goals and I'd like to have it here until the secrets stuff is a lot further along