### PR TITLE
Changed json entry from type: date to type: string / format: date-time

### DIFF
--- a/schemas/get-worker-type2-response.yml
+++ b/schemas/get-worker-type2-response.yml
@@ -76,7 +76,8 @@ properties:
       True if this worker type is allowed spot instances.  Currently ignored
       as all instances are Spot
   lastModified:
-    type: date
+    type: string
+    format: date-time
     description: |
       ISO Date string (e.g. new Date().toISOString()) which represents the time
       when this worker type definition was last altered (inclusive of creation)


### PR DESCRIPTION
@jhford 
This would make the date declarations consistent with other dates we have in our schemas. Also this would fix the parsing in taskcluster-client-go which unfortunately doesn't work with a date type. I think this is consistent with the allowed values in http://json-schema.org/latest/json-schema-core.html#anchor2 (see http://tools.ietf.org/html/rfc4627#section-2.1)