### PR TITLE
Typo fix for get-secret-response in json schema

### DIFF
--- a/schemas/get-secret-response.yml
+++ b/schemas/get-secret-response.yml
@@ -4,7 +4,7 @@ title:                      "Get Secret Response"
 description: |
   Secrets from the provisioner
 type:                       object
-properites:
+properties:
   data:
     type: object
     description: |


### PR DESCRIPTION
This allows the go client to interpret the response data.