### PR TITLE
ES6/7 fixes and roundrobin

### DIFF
--- a/lib/watchdog.js
+++ b/lib/watchdog.js
@@ -2,6 +2,7 @@
 
 var util = require('util');
 var events = require('events');
+var debug = require('debug')('watchdog');
 
 /**
  * This is a watch dog timer.  Think of it as a ticking
@@ -18,9 +19,11 @@ function WatchDog (maxTime) {
     var error = new Error('Watchdog expired!');
     // A better way to make this mandatory?
     if (that.listeners('expired').length > 0) {
+      debug('emitting expired event');
       that.emit('expired', error);
     } else {
-      throw error;
+      debug('exiting becase there is no expired event listener');
+      process.exit(1);
     }
   };
 }
@@ -33,6 +36,7 @@ util.inherits(WatchDog, events.EventEmitter);
 WatchDog.prototype.start = function () {
   this.__watchDog = setTimeout(this.action, this.maxTime * 1000);
   this.emit('started');
+  debug('started, emitted started event');
 };
 
 /**
@@ -40,9 +44,11 @@ WatchDog.prototype.start = function () {
  */
 WatchDog.prototype.stop = function () {
   if (this.__watchDog) {
+    debug('clearing timeout');
     clearTimeout(this.__watchDog);
   }
   this.emit('stopped');
+  debug('stopped, emitted stopped event');
 };
 
 /**
@@ -55,6 +61,7 @@ WatchDog.prototype.touch = function () {
   this.__watchDog = setTimeout(this.action, this.maxTime * 1000);
   clearTimeout(oldWD);
   this.emit('touched');
+  debug('touched, reset timer');
 };
 
 module.exports = WatchDog;

--- a/provisioner/provision.js
+++ b/provisioner/provision.js
@@ -205,13 +205,7 @@ Provisioner.prototype.spawn = async function (workerType, bid) {
   assert(workerType);
   assert(bid);
 
-  var launchInfo = workerType.createLaunchSpec(bid.region, bid.type);
-
-  // This should probably move from here to createLaunchSpec but that
-  // can happen later
-  launchInfo.launchSpec.Placement = {
-    AvailabilityZone: bid.zone,
-  };
+  var launchInfo = workerType.createLaunchSpec(bid);
 
   await this.Secret.create({
     token: launchInfo.securityToken,

--- a/provisioner/provision.js
+++ b/provisioner/provision.js
@@ -147,6 +147,7 @@ Provisioner.prototype.run = async function () {
       // And delay for the next one so we don't overwhelm EC2
       await d();
     } while (this.__keepRunning && !process.env.PROVISION_ONCE);
+    this.__watchDog.stop();
   } catch (err) {
     exitTimer(MAX_KILL_TIME);
     throw err;

--- a/provisioner/provision.js
+++ b/provisioner/provision.js
@@ -203,9 +203,9 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
       debug('%s needs %d capacity created', worker.workerType, change);
       var bids = worker.determineSpotBids(this.awsManager.ec2.regions, pricing, change);
       // This could probably be done cleaner
-      bids.forEach(bid => {
+      for (let bid of bids) {
         forSpawning.push({workerType: worker, bid: bid});
-      });
+      }
     } else if (change < 0) {
       var capToKill = -change;
       debug('%s needs %d capacity destroyed', worker.workerType, capToKill);
@@ -290,7 +290,7 @@ Provisioner.prototype.changeForType = async function (workerType, pricing) {
   return change;
 };
 
-Provisioner.prototype.destroyCapacity = async function (capacityToKill, workerType) {
+Provisioner.prototype.destroyCapacity = function (capacityToKill, workerType) {
   // We want to cancel spot requests when we no longer need them, but only
   // down to the minimum capacity
   var capacityToKill = -change;


### PR DESCRIPTION
Rather than trying to trace through all the random issues, I decided to finish moving the important things over to es6/7so that I could be sure related to `that.` weren't causing trouble as I've seen before.  I also implemented the round robin stuff that @jonasfj has wanted for a while.

The biggest outstanding question I have is whether I should be doing:
```javascript
// assume x is a list of promises
async function () {
  return await Promise.all(x)
}

// or

async function () {
  return Promise.all(x)
}

// or

function () {
  return Promise.all(x)
}
```