### PR TITLE
Cleanups and state improvements

### DIFF
--- a/bin/provisioner.js
+++ b/bin/provisioner.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var debug = require('debug')('aws-provisioner:bin:provisioner');
-var base = require('taskcluster-base');
-var provision = require('../lib/provision');
-var Aws = require('multi-region-promised-aws');
-var workerType = require('../lib/worker-type');
-var secret = require('../lib/secret');
-var workerState = require('../lib/worker-state');
-var AwsManager = require('../lib/aws-manager');
-var taskcluster = require('taskcluster-client');
-var _ = require('lodash');
+let debug = require('debug')('aws-provisioner:bin:provisioner');
+let base = require('taskcluster-base');
+let provision = require('../lib/provision');
+let Aws = require('multi-region-promised-aws');
+let workerType = require('../lib/worker-type');
+let secret = require('../lib/secret');
+let workerState = require('../lib/worker-state');
+let AwsManager = require('../lib/aws-manager');
+let taskcluster = require('taskcluster-client');
+let _ = require('lodash');
 
-var launch = function (profile) {
-  var cfg = base.config({
+let launch = function (profile) {
+  let cfg = base.config({
     defaults: require('../config/defaults.js'),
     profile: require('../config/' + profile),
     filename: 'taskcluster-aws-provisioner',
@@ -34,25 +34,25 @@ var launch = function (profile) {
     ],
   });
 
-  var allowedRegions = cfg.get('provisioner:allowedRegions').split(',');
-  var keyPrefix = cfg.get('provisioner:awsKeyPrefix');
-  var pubKey = cfg.get('provisioner:awsInstancePubkey');
-  var provisionerId = cfg.get('provisioner:id');
-  var provisionerBaseUrl = cfg.get('server:publicUrl') + '/v1';
-  var maxInstanceLife = cfg.get('provisioner:maxInstanceLife');
+  let allowedRegions = cfg.get('provisioner:allowedRegions').split(',');
+  let keyPrefix = cfg.get('provisioner:awsKeyPrefix');
+  let pubKey = cfg.get('provisioner:awsInstancePubkey');
+  let provisionerId = cfg.get('provisioner:id');
+  let provisionerBaseUrl = cfg.get('server:publicUrl') + '/v1';
+  let maxInstanceLife = cfg.get('provisioner:maxInstanceLife');
 
-  var influx = new base.stats.Influx({
+  let influx = new base.stats.Influx({
     connectionString: cfg.get('influx:connectionString'),
     maxDelay: cfg.get('influx:maxDelay'),
     maxPendingPoints: cfg.get('influx:maxPendingPoints'),
   });
 
-  var Secret = secret.setup({
+  let Secret = secret.setup({
     table: cfg.get('provisioner:secretTableName'),
     credentials: cfg.get('azure'),
   });
 
-  var WorkerType = workerType.setup({
+  let WorkerType = workerType.setup({
     table: cfg.get('provisioner:workerTypeTableName'),
     credentials: cfg.get('azure'),
     context: {
@@ -62,24 +62,24 @@ var launch = function (profile) {
     },
   });
 
-  var WorkerState = workerState.setup({
+  let WorkerState = workerState.setup({
     table: cfg.get('provisioner:workerStateTableName'),
     credentials: cfg.get('azure'),
   });
 
   // Create all the things which need to be injected into the
   // provisioner
-  var ec2 = new Aws('EC2', _.omit(cfg.get('aws'), 'region'), allowedRegions);
-  var awsManager = new AwsManager(
+  let ec2 = new Aws('EC2', _.omit(cfg.get('aws'), 'region'), allowedRegions);
+  let awsManager = new AwsManager(
       ec2,
       provisionerId,
       keyPrefix,
       pubKey,
       maxInstanceLife,
       influx);
-  var queue = new taskcluster.Queue({credentials: cfg.get('taskcluster:credentials')});
+  let queue = new taskcluster.Queue({credentials: cfg.get('taskcluster:credentials')});
 
-  var config = {
+  let config = {
     WorkerType: WorkerType,
     Secret: Secret,
     WorkerState: WorkerState,
@@ -91,7 +91,7 @@ var launch = function (profile) {
     provisionIterationInterval: cfg.get('provisioner:iterationInterval'),
   };
 
-  var provisioner = new provision.Provisioner(config);
+  let provisioner = new provision.Provisioner(config);
   try {
     provisioner.run();
   } catch (err) {
@@ -102,7 +102,7 @@ var launch = function (profile) {
 // Only start up the server if we are running as a script
 if (!module.parent) {
   // Find configuration profile
-  var profile_ = process.argv[2] || process.env.NODE_ENV;
+  let profile_ = process.argv[2] || process.env.NODE_ENV;
   if (!profile_) {
     console.log('Usage: server.js [profile]');
     console.error('ERROR: No configuration profile is provided');

--- a/bin/provisioner.js
+++ b/bin/provisioner.js
@@ -4,7 +4,7 @@ var debug = require('debug')('aws-provisioner:bin:provisioner');
 var base = require('taskcluster-base');
 var provision = require('../lib/provision');
 var Aws = require('multi-region-promised-aws');
-var data = require('../lib/data');
+var workerType = require('../lib/worker-type');
 var secret = require('../lib/secret');
 var workerState = require('../lib/worker-state');
 var AwsManager = require('../lib/aws-manager');
@@ -52,7 +52,7 @@ var launch = function (profile) {
     credentials: cfg.get('azure'),
   });
 
-  var WorkerType = data.WorkerType.setup({
+  var WorkerType = workerType.setup({
     table: cfg.get('provisioner:workerTypeTableName'),
     credentials: cfg.get('azure'),
     context: {

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,21 +1,21 @@
 #!/usr/bin/env node
 'use strict';
-var path = require('path');
-var debug = require('debug')('aws-provisioner:bin:server');
-var base = require('taskcluster-base');
-var workerType = require('../lib/worker-type');
-var secret = require('../lib/secret');
-var workerState = require('../lib/worker-state');
-var exchanges = require('../lib/exchanges');
-var v1 = require('../lib/routes/v1');
-var Aws = require('multi-region-promised-aws');
-var _ = require('lodash');
-var series = require('../lib/influx-series');
+let path = require('path');
+let debug = require('debug')('aws-provisioner:bin:server');
+let base = require('taskcluster-base');
+let workerType = require('../lib/worker-type');
+let secret = require('../lib/secret');
+let workerState = require('../lib/worker-state');
+let exchanges = require('../lib/exchanges');
+let v1 = require('../lib/routes/v1');
+let Aws = require('multi-region-promised-aws');
+let _ = require('lodash');
+let series = require('../lib/influx-series');
 
 /** Launch server */
-var launch = async function (profile) {
+let launch = async function (profile) {
   // Load configuration
-  var cfg = base.config({
+  let cfg = base.config({
     defaults: require('../config/defaults'),
     profile: require('../config/' + profile),
     envs: [
@@ -37,12 +37,12 @@ var launch = async function (profile) {
     filename: 'taskcluster-aws-provisioner',
   });
 
-  var keyPrefix = cfg.get('provisioner:awsKeyPrefix');
-  var provisionerId = cfg.get('provisioner:id');
-  var provisionerBaseUrl = cfg.get('server:publicUrl') + '/v1';
+  let keyPrefix = cfg.get('provisioner:awsKeyPrefix');
+  let provisionerId = cfg.get('provisioner:id');
+  let provisionerBaseUrl = cfg.get('server:publicUrl') + '/v1';
 
   // Create InfluxDB connection for submitting statistics
-  var influx = new base.stats.Influx({
+  let influx = new base.stats.Influx({
     connectionString: cfg.get('influx:connectionString'),
     maxDelay: cfg.get('influx:maxDelay'),
     maxPendingPoints: cfg.get('influx:maxPendingPoints'),
@@ -52,7 +52,7 @@ var launch = async function (profile) {
   // to run in any region, which we'll limit by the ones
   // store in the worker definition
   // NOTE: Should we use ec2.describeRegions? meh
-  var ec2 = new Aws('EC2', _.omit(cfg.get('aws'), 'region'), [
+  let ec2 = new Aws('EC2', _.omit(cfg.get('aws'), 'region'), [
     'us-east-1', 'us-west-1', 'us-west-2',
     'eu-west-1', 'eu-central-1',
     'ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1',
@@ -67,7 +67,7 @@ var launch = async function (profile) {
   });
 
   // Configure WorkerType entities
-  var WorkerType = workerType.setup({
+  let WorkerType = workerType.setup({
     table: cfg.get('provisioner:workerTypeTableName'),
     credentials: cfg.get('azure'),
     context: {
@@ -81,13 +81,13 @@ var launch = async function (profile) {
   });
 
   // Configure WorkerState entities
-  var WorkerState = workerState.setup({
+  let WorkerState = workerState.setup({
     table: cfg.get('provisioner:workerStateTableName'),
     credentials: cfg.get('azure'),
   });
 
   // Configure WorkerType entities
-  var Secret = secret.setup({
+  let Secret = secret.setup({
     table: cfg.get('provisioner:secretTableName'),
     credentials: cfg.get('azure'),
   });
@@ -170,7 +170,7 @@ var launch = async function (profile) {
 // If server.js is executed start the server
 if (!module.parent) {
   // Find configuration profile
-  var profile_ = process.argv[2] || process.env.NODE_ENV;
+  let profile_ = process.argv[2] || process.env.NODE_ENV;
   if (!profile_) {
     console.log('Usage: server.js [profile]');
     console.error('ERROR: No configuration profile is provided');

--- a/bin/server.js
+++ b/bin/server.js
@@ -3,7 +3,7 @@
 var path = require('path');
 var debug = require('debug')('aws-provisioner:bin:server');
 var base = require('taskcluster-base');
-var data = require('../lib/data');
+var workerType = require('../lib/worker-type');
 var secret = require('../lib/secret');
 var workerState = require('../lib/worker-state');
 var exchanges = require('../lib/exchanges');
@@ -94,7 +94,7 @@ var launch = async function (profile) {
   });
 
   // Configure WorkerType entities
-  var WorkerType = data.WorkerType.setup({
+  var WorkerType = workerType.setup({
     table: cfg.get('provisioner:workerTypeTableName'),
     credentials: cfg.get('azure'),
     context: {

--- a/config/test.js
+++ b/config/test.js
@@ -2,6 +2,7 @@ module.exports = {
   provisioner: {
     id:                   'aws-provisioner2-test',
     workerTypeTableName:  'atablefortesting',
+    workerStateTableName: 'workerstatetesting',
     secretTableName:      'ProvisionerSecretTest',
     publishMetaData:      'false',
     statsComponent:       'aws-provisioner2-test',

--- a/lib/aws-manager.js
+++ b/lib/aws-manager.js
@@ -3,7 +3,7 @@
 let Promise = require('promise');
 let assert = require('assert');
 let debug = require('debug')('aws-provisioner:aws-manager');
-let objFilter = require('../lib/objFilter');
+//let objFilter = require('../lib/objFilter');
 let shuffle = require('knuth-shuffle');
 let taskcluster = require('taskcluster-client');
 let series = require('./influx-series');
@@ -196,7 +196,16 @@ AwsManager.prototype.update = async function () {
   let stateDifferences = this._compareStates(this.__apiState, this.__previousApiState, this.__deadState);
   this._reconcileStateDifferences(stateDifferences, this.__deadState, this.__apiState);
 
-  await this.handleStalledRequests(filteredSpotRequests.stalled);
+  try {
+    await this.handleStalledRequests(filteredSpotRequests.stalled);
+  } catch (err) {
+    debug('error handling stalled spot requests');
+    debug(err);
+    if (err.stack) {
+      debug(err.stack);
+    }
+    throw err;
+  }
 
   // We want to make sure that our internal state is always up to date when
   // we fetch the updated state
@@ -210,12 +219,21 @@ AwsManager.prototype.update = async function () {
  * now
  */
 AwsManager.prototype.handleStalledRequests = async function (spotReqs) {
-  await Promise.all(Object.keys(spotReqs).map(region => {
-    return this.killCancel(region, [], spotReqs[region].map(sr => {
-      debug('killing stalled spot request ' + sr.SpotInstanceRequestId);
-      return sr.SpotInstanceRequestId;
+  try {
+    await Promise.all(Object.keys(spotReqs).map(region => {
+      return this.killCancel(region, [], spotReqs[region].map(sr => {
+        debug('killing stalled spot request ' + sr.SpotInstanceRequestId);
+        return sr.SpotInstanceRequestId;
+      }));
     }));
-  }));
+  } catch (err) {
+    debug('error killcancelling for stalled sr');
+    debug(err);
+    if (err.stack) {
+      debug(err.stack);
+    }
+    throw err;
+  }
 };
 
 /**
@@ -1344,7 +1362,6 @@ AwsManager.prototype.zombieKiller = function () {
 
 };
 
-
 /**
  * Create a thing which has the stuff to insert into a WorkerState entity
  */
@@ -1377,7 +1394,7 @@ AwsManager.prototype.stateForStorage = function (workerName) {
         ami: request.LaunchSpecification.ImageId,
         type: request.LaunchSpecification.InstanceType,
         zone: request.LaunchSpecification.Placement.AvailabilityZone,
-        'status': request.Status.Code,
+        status: request.Status.Code,
       });
     }
   }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -15,7 +15,7 @@
  * that you should be using.
  */
 function Cache (maxAgeMinutes, obj, func) {
-  var sliceFrom;
+  let sliceFrom;
   if (typeof obj === 'object') {
     this.obj = obj;
     if (typeof func === 'string') {
@@ -39,7 +39,7 @@ function Cache (maxAgeMinutes, obj, func) {
  * value has already expired
  */
 Cache.prototype.isValid = function () {
-  var now = new Date();
+  let now = new Date();
   if (this.data && this.expiration && now < this.expiration) {
     return true;
   }

--- a/lib/data.js
+++ b/lib/data.js
@@ -214,11 +214,20 @@ WorkerType.create = function (workerType, properties) {
 WorkerType.loadAll = async function () {
   let workers = [];
 
-  await base.Entity.scan.call(this, {}, {
-    handler: function (item) {
-      workers.push(item);
-    },
-  });
+  try {
+    await base.Entity.scan.call(this, {}, {
+      handler: function (item) {
+        workers.push(item);
+      },
+    });
+  } catch (err) {
+    debug('error loading all workers');
+    debug(err);
+    if (err.stack) {
+      debug(err.stack);
+    }
+    throw err;
+  }
 
   return workers;
 };
@@ -229,11 +238,20 @@ WorkerType.loadAll = async function () {
 WorkerType.listWorkerTypes = async function () {
   let names = [];
 
-  await base.Entity.scan.call(this, {}, {
-    handler: function (item) {
-      names.push(item.workerType);
-    },
-  });
+  try {
+    await base.Entity.scan.call(this, {}, {
+      handler: function (item) {
+        names.push(item.workerType);
+      },
+    });
+  } catch (err) {
+    debug('error listing worker names');
+    debug(err);
+    if (err.stack) {
+      debug(err.stack);
+    }
+    throw err;
+  }
 
   return names;
 };

--- a/lib/exchanges.js
+++ b/lib/exchanges.js
@@ -1,8 +1,8 @@
 'use strict';
-var base = require('taskcluster-base');
+let base = require('taskcluster-base');
 
 /** Declaration of exchanges offered by the aws-provisioner */
-var exchanges = new base.Exchanges({
+let exchanges = new base.Exchanges({
   title: 'AWS Provisioner Pulse Exchanges',
   description: [
     'Exchanges from the provisioner... more docs later',
@@ -13,7 +13,7 @@ var exchanges = new base.Exchanges({
 module.exports = exchanges;
 
 /** Common routing key construct for `exchanges.declare` */
-var commonRoutingKey = [
+let commonRoutingKey = [
   {
     // Let's keep the "primary." prefix, so we can support custom routing keys
     // in the future, I don't see a need for it here. But it's nice to have the
@@ -39,23 +39,23 @@ var commonRoutingKey = [
 ];
 
 /** Build an pulse compatible message from a message */
-var commonMessageBuilder = function (message) {
+let commonMessageBuilder = function (message) {
   message.version = 1;
   return message;
 };
 
 /** Build a routing-key from message */
-var commonRoutingKeyBuilder = function (message) {
+let commonRoutingKeyBuilder = function (message) {
   return {workerType: message.workerType};
 };
 
 /** Build a list of routes to CC */
-var commonCCBuilder = function () {
+let commonCCBuilder = function () {
   return [];
 };
 
 // Common schema prefix
-var SCHEMA_PREFIX_CONST = 'http://schemas.taskcluster.net/aws-provisioner/v1/';
+let SCHEMA_PREFIX_CONST = 'http://schemas.taskcluster.net/aws-provisioner/v1/';
 
 exchanges.declare({
   exchange: 'worker-type-created',

--- a/lib/influx-series.js
+++ b/lib/influx-series.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var base = require('taskcluster-base');
+let base = require('taskcluster-base');
 
 // This is a time series to measure how long it takes for instances to show up
 // in the AWS api responses

--- a/lib/objFilter.js
+++ b/lib/objFilter.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var assert = require('assert');
-var lodash = require('lodash');
+let assert = require('assert');
+let lodash = require('lodash');
 
 /**
  * Pick keys recursively from objects.  Obj is
@@ -10,7 +10,7 @@ var lodash = require('lodash');
  * of the source object.
  * Examples:
 
-  var source = {a: {b: {c: 1, e: 2}}, d: 3}
+  let source = {a: {b: {c: 1, e: 2}}, d: 3}
 
   recursiveObjectPicker(source, ["a"]) # --> { a: { b: { c: 1, e: 2 } } }
   recursiveObjectPicker(source, ["a:b:c"]) # --> { a: { b: { c: 1 } } }
@@ -20,19 +20,19 @@ var lodash = require('lodash');
 function recursiveObjectFilter (obj, keys) {
   assert(typeof obj === 'object');
   assert(Array.isArray(keys));
-  var newObj = {};
-  keys.forEach(function (key) {
-    var props = key.split(':');
+  let newObj = {};
+  for (let key of keys) {
+    let props = key.split(':');
 
-    var p = obj;
-    var d = newObj;
+    let p = obj;
+    let d = newObj;
 
     // Probably should merge these two loops into one...
-    props.forEach(function (prop) {
+    for (let prop of props) {
       p = p[prop];
-    });
+    }
 
-    props.forEach(function (prop, idx, arr) {
+    props.forEach(function (prop, idx, arr) { // eslint-disable-line no-loop-func
       if (d[prop]) {
         if (typeof d[prop] !== 'object') {
           throw new Error('trying to assign property to non-object (%j)', d[prop]);
@@ -56,7 +56,7 @@ function recursiveObjectFilter (obj, keys) {
       }
     });
 
-  });
+  }
 
   return newObj;
 }

--- a/lib/provision.js
+++ b/lib/provision.js
@@ -172,10 +172,19 @@ Provisioner.prototype.stop = function () {
  * Run provisioners for all known worker types once
  */
 Provisioner.prototype.runAllProvisionersOnce = async function () {
-  let res = await Promise.all([
-    this.WorkerType.loadAll(),
-    this.awsManager.update(),
-  ]);
+  try {
+    let res = await Promise.all([
+      this.WorkerType.loadAll(),
+      this.awsManager.update(),
+    ]);
+  } catch (err) {
+    debug('error loading workertypes or updating ec2 state');
+    debug(err);
+    if (err.stack) {
+      debug(err.stack);
+    }
+    throw err;
+  }
 
   let workerTypes = res[0];
 
@@ -183,14 +192,22 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
     return x.workerType; // can't remember the nice es7 for this
   });
 
-  await Promise.all([
-    this.awsManager.rougeKiller(workerNames),
-    this.awsManager.zombieKiller(),
-    this.awsManager.ensureTags(),
-    workerNames.map(name => {
-      return this.awsManager.createKeyPair(name);
-    }),
-  ]);
+  try {
+    await Promise.all([
+      this.awsManager.rougeKiller(workerNames),
+      this.awsManager.zombieKiller(),
+      this.awsManager.ensureTags(),
+      workerNames.map(name => {
+        return this.awsManager.createKeyPair(name);
+      }),
+    ]);
+  } catch (err) {
+    debug('failure running housekeeping tasks');
+    debug(err);
+    if (err.stack) {
+      debug(err.stack);
+    }
+  }
 
   debug('configured workers:           %j', workerNames);
   debug('managed requests/instances:   %j', this.awsManager.knownWorkerTypes());
@@ -198,7 +215,16 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
   let forSpawning = [];
 
   for (let worker of workerTypes) {
-    let change = await this.changeForType(worker);
+    try {
+      let change = await this.changeForType(worker);
+    } catch (err4) {
+      debug('error getting change for a type');
+      debug(err4);
+      if (err4.stack) {
+        debug(err4.stack);
+      }
+      throw err4;
+    }
     let state = this.awsManager.stateForStorage(worker.workerType);
     try {
       // This does create a bunch of extra logs... darn!
@@ -211,7 +237,6 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
           this.instances = state.instances;
           this.requests = state.requests;
         });
-        debug('hihihi');
       } catch (err2) {
         debug('[alert-operator] failed to update state for %s', worker.workerType);
         debug(err2);
@@ -231,8 +256,17 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
     } else if (change < 0) {
       let capToKill = -change;
       debug('%s needs %d capacity destroyed', worker.workerType, capToKill);
-      await this.awsManager.killCapacityOfWorkerType(
-            worker, capToKill, ['pending', 'spotReq']);
+      try {
+        await this.awsManager.killCapacityOfWorkerType(
+              worker, capToKill, ['pending', 'spotReq']);
+      } catch (err3) {
+        debug('error running the capacity killer');
+        debug(err3);
+        if (err3.stack) {
+          debug(err3.stack);
+        }
+        throw err3;
+      }
     } else {
       debug('%s needs no changes', worker.workerType);
     }
@@ -254,7 +288,12 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
       await this.spawn(toSpawn.workerType, toSpawn.bid);
       await d();
     } catch (err) {
-      await longD();
+      try {
+        await longD();
+      } catch (err6) {
+        debug(err6);
+        debug(err6.stack);
+      }
       debug('ERROR! there was an error with bid %j: %j %s', toSpawn.bid, err, err.stack);
       forSpawning.push(toSpawn);
     }
@@ -271,13 +310,22 @@ Provisioner.prototype.spawn = async function (workerType, bid) {
 
   let launchInfo = workerType.createLaunchSpec(bid);
 
-  await this.Secret.create({
-    token: launchInfo.securityToken,
-    workerType: workerType.workerType,
-    secrets: launchInfo.secrets,
-    scopes: launchInfo.scopes,
-    expiration: taskcluster.fromNow('40 minutes'),
-  });
+  try {
+    await this.Secret.create({
+      token: launchInfo.securityToken,
+      workerType: workerType.workerType,
+      secrets: launchInfo.secrets,
+      scopes: launchInfo.scopes,
+      expiration: taskcluster.fromNow('40 minutes'),
+    });
+  } catch (err) {
+    debug('error inserting secret into storage');
+    debug(err);
+    if (err.stack) {
+      debug(err.stack);
+    }
+    throw err;
+  }
 
   return this.awsManager.requestSpotInstance(launchInfo, bid);
 };
@@ -286,8 +334,16 @@ Provisioner.prototype.spawn = async function (workerType, bid) {
  * Determine the change for a given worker type
  */
 Provisioner.prototype.changeForType = async function (workerType) {
-  let result = await this.queue.pendingTasks(
-      this.provisionerId, workerType.workerType);
+  try {
+    let result = await this.queue.pendingTasks(this.provisionerId, workerType.workerType);
+  } catch (err) {
+    debug('error checking queue for pending tasks');
+    debug(err);
+    if (err.stack) {
+      debug(err.stack);
+    }
+    throw err;
+  }
   let pendingTasks = result.pendingTasks;
   let runningCapacity = this.awsManager.capacityForType(workerType, ['running']);
   let pendingCapacity = this.awsManager.capacityForType(workerType, ['pending', 'spotReq']);

--- a/lib/provision.js
+++ b/lib/provision.js
@@ -172,8 +172,9 @@ Provisioner.prototype.stop = function () {
  * Run provisioners for all known worker types once
  */
 Provisioner.prototype.runAllProvisionersOnce = async function () {
+  let res;
   try {
-    let res = await Promise.all([
+    res = await Promise.all([
       this.WorkerType.loadAll(),
       this.awsManager.update(),
     ]);
@@ -215,8 +216,9 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
   let forSpawning = [];
 
   for (let worker of workerTypes) {
+    let change;
     try {
-      let change = await this.changeForType(worker);
+      change = await this.changeForType(worker);
     } catch (err4) {
       debug('error getting change for a type');
       debug(err4);
@@ -232,7 +234,7 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
     } catch (err) {
       try {
         let stateEntity = await this.WorkerState.load({workerType: worker.workerType});
-        await stateEntity.modify(function () {
+        await stateEntity.modify(function () { // eslint-disable-line no-loop-func
           //debug('%j\n\n \\/ \n\n%j', s, state);
           this.instances = state.instances;
           this.requests = state.requests;
@@ -334,8 +336,9 @@ Provisioner.prototype.spawn = async function (workerType, bid) {
  * Determine the change for a given worker type
  */
 Provisioner.prototype.changeForType = async function (workerType) {
+  let result;
   try {
-    let result = await this.queue.pendingTasks(this.provisionerId, workerType.workerType);
+    result = await this.queue.pendingTasks(this.provisionerId, workerType.workerType);
   } catch (err) {
     debug('error checking queue for pending tasks');
     debug(err);
@@ -344,6 +347,7 @@ Provisioner.prototype.changeForType = async function (workerType) {
     }
     throw err;
   }
+
   let pendingTasks = result.pendingTasks;
   let runningCapacity = this.awsManager.capacityForType(workerType, ['running']);
   let pendingCapacity = this.awsManager.capacityForType(workerType, ['pending', 'spotReq']);

--- a/lib/provision.js
+++ b/lib/provision.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var Promise = require('promise');
-var debug = require('debug')('aws-provisioner:provision');
-var assert = require('assert');
-var WatchDog = require('./watchdog');
-var taskcluster = require('taskcluster-client');
-var delayer = require('./delayer');
-var shuffle = require('knuth-shuffle');
+let Promise = require('promise');
+let debug = require('debug')('aws-provisioner:provision');
+let assert = require('assert');
+let WatchDog = require('./watchdog');
+let taskcluster = require('taskcluster-client');
+let delayer = require('./delayer');
+let shuffle = require('knuth-shuffle');
 
-var series = require('./influx-series');
+let series = require('./influx-series');
 
 const MAX_PROVISION_ITERATION = 1000 * 60 * 10; // 10 minutes
 const MAX_KILL_TIME = 1000 * 30;
@@ -82,7 +82,7 @@ module.exports.Provisioner = Provisioner;
  * exit
  */
 function exitTimer (time) {
-  var t = time || 30000;
+  let t = time || 30000;
   setTimeout(() => {
     debug('hey, so you probably are trying to figure out');
     debug('why this process suddenly disappeared.  a major');
@@ -125,7 +125,7 @@ Provisioner.prototype.run = async function () {
         throw new Error('provisioner is failing a lot');
       }
 
-      var outcome;
+      let outcome;
 
       this.__stats.runs++;
 
@@ -172,14 +172,14 @@ Provisioner.prototype.stop = function () {
  * Run provisioners for all known worker types once
  */
 Provisioner.prototype.runAllProvisionersOnce = async function () {
-  var res = await Promise.all([
+  let res = await Promise.all([
     this.WorkerType.loadAll(),
     this.awsManager.update(),
   ]);
 
-  var workerTypes = res[0];
+  let workerTypes = res[0];
 
-  var workerNames = workerTypes.map(x => {
+  let workerNames = workerTypes.map(x => {
     return x.workerType; // can't remember the nice es7 for this
   });
 
@@ -195,17 +195,17 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
   debug('configured workers:           %j', workerNames);
   debug('managed requests/instances:   %j', this.awsManager.knownWorkerTypes());
 
-  var forSpawning = [];
+  let forSpawning = [];
 
-  for (var worker of workerTypes) {
-    var change = await this.changeForType(worker);
-    var state = this.awsManager.stateForStorage(worker.workerType);
+  for (let worker of workerTypes) {
+    let change = await this.changeForType(worker);
+    let state = this.awsManager.stateForStorage(worker.workerType);
     try {
       // This does create a bunch of extra logs... darn!
       await this.WorkerState.create(state);
     } catch (err) {
       try {
-        var stateEntity = await this.WorkerState.load({workerType: worker.workerType});
+        let stateEntity = await this.WorkerState.load({workerType: worker.workerType});
         await stateEntity.modify(function () {
           //debug('%j\n\n \\/ \n\n%j', s, state);
           this.instances = state.instances;
@@ -223,13 +223,13 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
 
     if (change > 0) {
       debug('%s needs %d capacity created', worker.workerType, change);
-      var bids = worker.determineSpotBids(this.awsManager.ec2.regions, this.awsManager.__pricing, change);
+      let bids = worker.determineSpotBids(this.awsManager.ec2.regions, this.awsManager.__pricing, change);
       // This could probably be done cleaner
       for (let bid of bids) {
         forSpawning.push({workerType: worker, bid: bid});
       }
     } else if (change < 0) {
-      var capToKill = -change;
+      let capToKill = -change;
       debug('%s needs %d capacity destroyed', worker.workerType, capToKill);
       await this.awsManager.killCapacityOfWorkerType(
             worker, capToKill, ['pending', 'spotReq']);
@@ -242,14 +242,14 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
   const longD = delayer(2000);
 
   // We want to have a maximum number of attempts
-  var attemptsLeft = forSpawning.length * 2;
+  let attemptsLeft = forSpawning.length * 2;
 
   // We want to shuffle up the bids so that we don't prioritize
   // any particular worker type
   forSpawning = shuffle.knuthShuffle(forSpawning);
 
   while (forSpawning.length > 0 && attemptsLeft-- > 0) {
-    var toSpawn = forSpawning.shift();
+    let toSpawn = forSpawning.shift();
     try {
       await this.spawn(toSpawn.workerType, toSpawn.bid);
       await d();
@@ -269,7 +269,7 @@ Provisioner.prototype.spawn = async function (workerType, bid) {
   assert(workerType);
   assert(bid);
 
-  var launchInfo = workerType.createLaunchSpec(bid);
+  let launchInfo = workerType.createLaunchSpec(bid);
 
   await this.Secret.create({
     token: launchInfo.securityToken,
@@ -286,12 +286,12 @@ Provisioner.prototype.spawn = async function (workerType, bid) {
  * Determine the change for a given worker type
  */
 Provisioner.prototype.changeForType = async function (workerType) {
-  var result = await this.queue.pendingTasks(
+  let result = await this.queue.pendingTasks(
       this.provisionerId, workerType.workerType);
-  var pendingTasks = result.pendingTasks;
-  var runningCapacity = this.awsManager.capacityForType(workerType, ['running']);
-  var pendingCapacity = this.awsManager.capacityForType(workerType, ['pending', 'spotReq']);
-  var change = workerType.determineCapacityChange(
+  let pendingTasks = result.pendingTasks;
+  let runningCapacity = this.awsManager.capacityForType(workerType, ['running']);
+  let pendingCapacity = this.awsManager.capacityForType(workerType, ['pending', 'spotReq']);
+  let change = workerType.determineCapacityChange(
       runningCapacity, pendingCapacity, pendingTasks);
   debug('%s: %d running capacity, %d pending capacity and %d pending tasks',
       workerType.workerType, runningCapacity, pendingCapacity, pendingTasks);

--- a/lib/routes/v1.js
+++ b/lib/routes/v1.js
@@ -1,11 +1,11 @@
 'use strict';
-var debug = require('debug')('routes:v1');
-var base = require('taskcluster-base');
-var taskcluster = require('taskcluster-client');
-var _ = require('lodash');
+let debug = require('debug')('routes:v1');
+let base = require('taskcluster-base');
+let taskcluster = require('taskcluster-client');
+let _ = require('lodash');
 
 // Common schema prefix
-var SCHEMA_PREFIX_CONST = 'http://schemas.taskcluster.net/aws-provisioner/v1/';
+let SCHEMA_PREFIX_CONST = 'http://schemas.taskcluster.net/aws-provisioner/v1/';
 
 /**
  * API end-point for version v1/
@@ -16,7 +16,7 @@ var SCHEMA_PREFIX_CONST = 'http://schemas.taskcluster.net/aws-provisioner/v1/';
  *   WorkerType:        // Instance of data.WorkerType
  * }
  */
-var api = new base.API({
+let api = new base.API({
   title: 'AWS Provisioner API Documentation',
   description: [
     'The AWS Provisioner is responsible for provisioning instances on EC2 for use in',
@@ -59,8 +59,8 @@ api.declare({
     'KeyPair',
   ].join('\n'),
 }, async function (req, res) {
-  var input = req.body;
-  var workerType = req.params.workerType;
+  let input = req.body;
+  let workerType = req.params.workerType;
 
   input.lastModified = new Date();
 
@@ -98,7 +98,7 @@ api.declare({
   }
 
   // Create workerType
-  var wType;
+  let wType;
   try {
     wType = await this.WorkerType.create(workerType, input);
   } catch (err) {
@@ -109,7 +109,7 @@ api.declare({
     wType = await this.WorkerType.load({workerType});
 
     // Check the it matches the existing workerType
-    var match = [
+    let match = [
       'launchSpec',
       'userData',
       'secrets',
@@ -142,7 +142,7 @@ api.declare({
     workerType: workerType,
   });
 
-  var workerjson = wType.json();
+  let workerjson = wType.json();
   delete workerjson.canUseOnDemand;
   workerjson.canUseOndemand = false;
   res.reply(workerjson);
@@ -164,10 +164,10 @@ api.declare({
     'KeyPair',
   ].join('\n'),
 }, async function (req, res) {
-  var input = req.body;
-  var workerType = req.params.workerType;
+  let input = req.body;
+  let workerType = req.params.workerType;
 
-  var modDate = new Date();
+  let modDate = new Date();
 
   input.lastModified = modDate;
 
@@ -194,7 +194,7 @@ api.declare({
     });
   }
 
-  var wType = await this.WorkerType.load({workerType: workerType});
+  let wType = await this.WorkerType.load({workerType: workerType});
 
   await wType.modify(function (w) {
     // We know that data that gets to here is valid per-schema
@@ -228,7 +228,7 @@ api.declare({
     'Retreive a WorkerType definition',
   ].join('\n'),
 }, async function (req, res) {
-  var workerType = req.params.workerType;
+  let workerType = req.params.workerType;
 
   if (!req.satisfies({workerType: workerType})) { return undefined; }
 
@@ -270,8 +270,8 @@ api.declare({
     'instances and delete the KeyPair from all configured EC2 regions',
   ].join('\n'),
 }, async function (req, res) {
-  var that = this;
-  var workerType = req.params.workerType;
+  let that = this;
+  let workerType = req.params.workerType;
 
   if (!req.satisfies({workerType: workerType})) { return undefined; }
 
@@ -311,7 +311,7 @@ api.declare({
 }, async function (req, res) {
 
   try {
-    var list = await this.WorkerType.listWorkerTypes();
+    let list = await this.WorkerType.listWorkerTypes();
     return res.reply(list);
   } catch (err) {
     debug('error listing workertypes');
@@ -336,10 +336,10 @@ api.declare({
     'and completeness',
   ].join('\n'),
 }, async function (req, res) {
-  var input = req.body;
-  var token = req.params.token;
+  let input = req.body;
+  let token = req.params.token;
 
-  var secret;
+  let secret;
   try {
     secret = await this.Secret.create({
       token: token,
@@ -358,7 +358,7 @@ api.declare({
       provisionerId: this.provisionerId,
     });
 
-    var match = [
+    let match = [
       'workerType',
       'secrets',
       'token',
@@ -395,10 +395,10 @@ api.declare({
     'process which can read HTTP on the worker localhost interface.',
   ].join('\n'),
 }, async function (req, res) {
-  var token = req.params.token;
+  let token = req.params.token;
 
   try {
-    var secret = await this.Secret.load({
+    let secret = await this.Secret.load({
       token: token,
     });
 
@@ -438,8 +438,8 @@ api.declare({
     'but that seems like overkill',
   ].join('\n'),
 }, async function (req, res) {
-  var instanceId = req.params.instanceId;
-  var token = req.params.token;
+  let instanceId = req.params.instanceId;
+  let token = req.params.token;
 
   try {
     await this.Secret.load({
@@ -473,7 +473,7 @@ api.declare({
     'and use the getSecrete() api here to get the secrets',
   ].join('\n'),
 }, async function (req, res) {
-  var token = req.params.token;
+  let token = req.params.token;
 
   try {
     await this.Secret.remove({
@@ -516,12 +516,12 @@ api.declare({
     '**This API end-point is experimental and may be subject to change without warning.**',
   ].join('\n'),
 }, async function (req, res) {
-  var workerType = req.params.workerType;
+  let workerType = req.params.workerType;
 
   if (!req.satisfies({workerType: workerType})) { return undefined; }
 
-  var worker = await this.WorkerType.load({workerType: workerType});
-  var outcome;
+  let worker = await this.WorkerType.load({workerType: workerType});
+  let outcome;
   try {
     outcome = worker.testLaunchSpecs();
   } catch (err) {
@@ -550,9 +550,9 @@ api.declare({
     'in the provisioner.',
   ].join('\n'),
 }, async function (req, res) {
-  var workerType = req.params.workerType;
+  let workerType = req.params.workerType;
   try {
-    var workerState = await this.WorkerState.load({workerType: workerType});
+    let workerState = await this.WorkerState.load({workerType: workerType});
     res.reply(workerState._properties);
   } catch (err) {
     if (err.code === 'ResourceNotFound') {
@@ -591,8 +591,8 @@ api.declare({
     '**Warning** this api end-point is **not stable**.',
   ].join('\n'),
 }, function (req, res) {
-  var host = req.get('host');
-  var proto = req.connection.encrypted ? 'https' : 'http';
+  let host = req.get('host');
+  let proto = req.connection.encrypted ? 'https' : 'http';
   res.status(200).json(api.reference({
     baseUrl: proto + '://' + host + '/v1',
   }));

--- a/lib/routes/v1.js
+++ b/lib/routes/v1.js
@@ -84,9 +84,9 @@ api.declare({
     }
     debug('InvalidLaunchSpecifications!');
     if (err.reasons) {
-      err.reasons.forEach(reason => {
+      for (let reason of err.reasons) {
         debug(reason);
-      });
+      }
     }
     res.status(400).json({
       message: 'Invalid launchSpecification',
@@ -182,9 +182,9 @@ api.declare({
     }
     debug('InvalidLaunchSpecifications!');
     if (err.reasons) {
-      err.reasons.forEach(reason => {
+      for (let reason of err.reasons) {
         debug(reason);
-      });
+      }
     }
     return res.status(400).json({
       message: 'Invalid launchSpecification',
@@ -198,10 +198,10 @@ api.declare({
 
   await wType.modify(function (w) {
     // We know that data that gets to here is valid per-schema
-    Object.keys(input).forEach(function (key) {
+    for (let key of Object.keys(input)) {
       w[key] = input[key];
       w.lastModified = modDate;
-    });
+    }
   });
 
   // Publish pulse message
@@ -527,10 +527,10 @@ api.declare({
   } catch (err) {
     outcome = [];
     if (err.reasons) {
-      err.reasons.forEach(function (e) {
+      for (let e of err.reasons) {
         console.error(e, e.stack);
         outcome.push({error: e, stack: e.stack});
-      });
+      }
     }
   } finally {
     return res.reply(outcome);

--- a/lib/routes/v1.js
+++ b/lib/routes/v1.js
@@ -43,7 +43,7 @@ var api = new base.API({
   ].join('\n'),
 });
 
-function errorHandler (err, res, workerType) {
+function DEADCODEerrorHandler (err, res, workerType) {
   console.error(err, err.stack);
   switch (err.code) {
     case 'ResourceNotFound':
@@ -262,28 +262,32 @@ api.declare({
   description: [
     'Retreive a WorkerType definition',
   ].join('\n'),
-}, function (req, res) {
+}, async function (req, res) {
   var workerType = req.params.workerType;
 
   if (!req.satisfies({workerType: workerType})) { return undefined; }
 
-  var p = this.WorkerType.load({workerType: workerType});
+  let worker;
+  try {
+    worker = await this.WorkerType.load({workerType: workerType});
 
-  p = p.then(function (worker) {
-    var workerjson = worker.json();
+    // We do this because John made a mistake in the V1->V2
+    // schema update and there was a typo :(
+    let workerjson = worker.json();
     workerjson.canUseOndemand = false;
     delete workerjson.canUseOnDemand;
 
     return res.reply(workerjson);
-  });
-
-  p = p.catch(function (err) {
-    errorHandler(err, res, workerType);
-    return err;
-  });
-
-  return p;
-
+  } catch (err) {
+    if (err.code === 'ResourceNotFound') {
+      res.status(404).json({
+        error: err.code,
+        msg: workerType + ' not found',
+      });
+    } else {
+      throw err;
+    }
+  }
 });
 
 // Delete workerType
@@ -302,36 +306,29 @@ api.declare({
     'Delete a WorkerType definition, submits requests to kill all ',
     'instances and delete the KeyPair from all configured EC2 regions',
   ].join('\n'),
-}, function (req, res) {
+}, async function (req, res) {
   var that = this;
   var workerType = req.params.workerType;
 
   if (!req.satisfies({workerType: workerType})) { return undefined; }
 
-  var p = this.WorkerType.load({workerType: workerType});
-
-  p = p.then(function (worker) {
-    return worker.remove();
-  });
-
-  p = p.then(function () {
-    debug('Finished deleting worker type');
-    return res.reply({});
-  });
-
-  // Publish pulse message
-  p = p.then(function () {
-    return that.publisher.workerTypeRemoved({
+  try {
+    await this.WorkerType.remove({workerType: workerType}, true);
+    await that.publisher.workerTypeRemoved({
       workerType: workerType,
     });
-  });
-
-  p = p.catch(function (err) {
-    errorHandler(err, res, workerType);
-    return err;
-  });
-
-  return p;
+  } catch (err) {
+    if (err.code === 'ResourceNotFound') {
+      res.status(204).end();
+    } else {
+      debug('unknown error deleting ' + workerType);
+      debug(err);
+      if (err.stack) {
+        debug(err.stack);
+      }
+      throw err;
+    }
+  }
 });
 
 api.declare({
@@ -347,21 +344,19 @@ api.declare({
   description: [
     'List all known WorkerType names',
   ].join('\n'),
-}, function (req, res) {
+}, async function (req, res) {
 
-  var p = this.WorkerType.listWorkerTypes();
-
-  p = p.then(function (workerNames) {
+  try {
+    var list = await this.WorkerType.listWorkerTypes();
     return res.reply(workerNames);
-  });
-
-  p = p.catch(function (err) {
-    errorHandler(err, res, 'listing all worker types');
-    return err;
-  });
-
-  return p;
-
+  } catch (err) {
+    debug('error listing workertypes');
+    debug(err);
+    if (err.stack) {
+      debug(err.stack);
+    }
+    throw err;
+  }
 });
 
 api.declare({
@@ -437,13 +432,12 @@ api.declare({
   ].join('\n'),
 }, async function (req, res) {
   var token = req.params.token;
-  var that = this;
 
-  var p = this.Secret.load({
-    token: token,
-  });
+  try {
+    var secret = await this.Secret.load({
+      token: token,
+    });
 
-  p = p.then(function (secret) {
     return res.reply({
       data: secret.secrets,
       scopes: secret.scopes,
@@ -453,14 +447,14 @@ api.declare({
         credentials: that.credentials,
       }),
     });
-  });
-
-  p = p.catch(function (err) {
-    errorHandler(err, res, token);
-    return err;
-  });
-
-  return p;
+  } catch (err) {
+    debug('error getting secret ' + token);
+    debug(err);
+    if (err.stack) {
+      debug(err.stack);
+    }
+    throw err;
+  }
 });
 
 api.declare({
@@ -478,25 +472,24 @@ api.declare({
 }, async function (req, res) {
   var instanceId = req.params.instanceId;
   var token = req.params.token;
-  var that = this;
 
-  var p = this.Secret.load({
-    token: token,
-  });
+  try {
+    var secret = await this.Secret.load({
+      token: token,
+    });
 
-  p = p.then(function () {
     that.reportInstanceStarted({
       id: instanceId,
     });
     return res.status(204).end();
-  });
-
-  p = p.catch(function (err) {
-    errorHandler(err, res, token);
-    return err;
-  });
-
-  return p;
+  } catch (err) {
+    debug('error reporting instance %s start with token %s', instanceId, token);
+    debug(err);
+    if (err.stack) {
+      debug(err.stack);
+    }
+    throw err;
+  }
 });
 
 api.declare({
@@ -513,23 +506,22 @@ api.declare({
 }, async function (req, res) {
   var token = req.params.token;
 
-  var p = this.Secret.remove({
-    token: token,
-  }, true);
-
-  p = p.then(function () {
-    res.status(204).end();
-  });
-
-  p = p.catch(function (err) {
+  try {
+    var p = await this.Secret.remove({
+      token: token,
+    }, true);
+  } catch (err) {
     if (err.code === 'ResourceNotFound') {
       res.status(204).end();
     } else {
-      errorHandler(err, res, token);
+      debug('error removing a secret');
+      debug(err);
+      if (err.stack) {
+        debug(err.stack);
+      }
+      throw err;
     }
-  });
-
-  return p;
+  }
 });
 
 /** Utility methods below */
@@ -553,23 +545,13 @@ api.declare({
     '',
     '**This API end-point is experimental and may be subject to change without warning.**',
   ].join('\n'),
-}, function (req, res) {
+}, async function (req, res) {
   var workerType = req.params.workerType;
 
   if (!req.satisfies({workerType: workerType})) { return undefined; }
 
-  var p = this.WorkerType.load({workerType: workerType});
-
-  p = p.then(function (worker) {
-    return res.reply(worker.testLaunchSpecs());
-  });
-
-  p = p.catch(function (err) {
-    errorHandler(err, res, workerType);
-  });
-
-  return p;
-
+  var worker = await this.WorkerType.load({workerType: workerType});
+  return res.reply(worker.testLaunchSpecs());
 });
 
 api.declare({

--- a/lib/routes/v1.js
+++ b/lib/routes/v1.js
@@ -43,41 +43,6 @@ var api = new base.API({
   ].join('\n'),
 });
 
-function DEADCODEerrorHandler (err, res, workerType) {
-  console.error(err, err.stack);
-  switch (err.code) {
-    case 'ResourceNotFound':
-      return res.status(404).json({
-        message: workerType + ': not found',
-        error: {
-          workerType: workerType,
-          reason: err.code,
-        },
-      });
-    case 'EntityAlreadyExists':
-      return res.status(409).json({
-        message: workerType + ': already exists',
-        error: {
-          workerType: workerType,
-          reason: err.code,
-        },
-      });
-    case 'InvalidLaunchSpecifications':
-      if (err.reasons) {
-        err.reasons.forEach(function (e) {
-          console.error(e, e.stack);
-        });
-      }
-      return res.status(500).json({
-        message: err.toString(),
-        code: err.code,
-        reason: err.reasons.map(function (x) { return x.toString(); }),
-      });
-    default:
-      throw err;
-  }
-}
-
 module.exports = api;
 
 api.declare({
@@ -290,8 +255,6 @@ api.declare({
   }
 });
 
-// Delete workerType
-// TODO: send a pulse message that a worker type was removed
 api.declare({
   method: 'delete',
   route: '/worker-type/:workerType',
@@ -317,6 +280,7 @@ api.declare({
     await that.publisher.workerTypeRemoved({
       workerType: workerType,
     });
+    res.status(204).end();
   } catch (err) {
     if (err.code === 'ResourceNotFound') {
       res.status(204).end();
@@ -348,7 +312,7 @@ api.declare({
 
   try {
     var list = await this.WorkerType.listWorkerTypes();
-    return res.reply(workerNames);
+    return res.reply(list);
   } catch (err) {
     debug('error listing workertypes');
     debug(err);
@@ -444,16 +408,20 @@ api.declare({
       credentials: taskcluster.createTemporaryCredentials({
         scopes: secret.scopes,
         expiry: taskcluster.fromNow('96 hours'),
-        credentials: that.credentials,
+        credentials: this.credentials,
       }),
     });
   } catch (err) {
-    debug('error getting secret ' + token);
-    debug(err);
-    if (err.stack) {
-      debug(err.stack);
+    if (err.code === 'ResourceNotFound') {
+      res.status(404).end();
+    } else {
+      debug('error getting secret ' + token);
+      debug(err);
+      if (err.stack) {
+        debug(err.stack);
+      }
+      throw err;
     }
-    throw err;
   }
 });
 
@@ -474,13 +442,14 @@ api.declare({
   var token = req.params.token;
 
   try {
-    var secret = await this.Secret.load({
+    await this.Secret.load({
       token: token,
     });
 
-    that.reportInstanceStarted({
+    this.reportInstanceStarted({
       id: instanceId,
     });
+
     return res.status(204).end();
   } catch (err) {
     debug('error reporting instance %s start with token %s', instanceId, token);
@@ -507,9 +476,10 @@ api.declare({
   var token = req.params.token;
 
   try {
-    var p = await this.Secret.remove({
+    await this.Secret.remove({
       token: token,
     }, true);
+    res.status(204).end();
   } catch (err) {
     if (err.code === 'ResourceNotFound') {
       res.status(204).end();
@@ -551,112 +521,20 @@ api.declare({
   if (!req.satisfies({workerType: workerType})) { return undefined; }
 
   var worker = await this.WorkerType.load({workerType: workerType});
-  return res.reply(worker.testLaunchSpecs());
-});
-
-api.declare({
-  method: 'post',
-  route: '/worker-type/:workerType/terminate-all-instances',
-  name: 'terminateAllInstancesOfWorkerType',
-  title: 'Shutdown Every Ec2 Instance of this Worker Type',
-  scopes: [
-    [
-      'aws-provisioner:all-stop',
-      'aws-provisioner:aws',
-    ],
-  ],
-  description: [
-    'WARNING: YOU ALMOST CERTAINLY DO NOT WANT TO USE THIS ',
-    'Shut down every single EC2 instance associated with this workerType. ',
-    'This means every single last one.  You probably don\'t want to use ',
-    'this method, which is why it has an obnoxious name.  Don\'t even try ',
-    'to claim you didn\'t know what this method does!',
-    '',
-    '**This API end-point is experimental and may be subject to change without warning.**',
-  ].join('\n'),
-}, function (req, res) {
-  var workerType = req.params.workerType;
-
-  debug('SOMEONE IS TURNING OFF ALL ' + workerType);
-
-  var p = this.awsManager.killByName(workerType);
-
-  p = p.then(function () {
-    res.reply({
-      outcome: true,
-      message: 'You just turned off all ' + workerType + '.  Feel the power!',
-    });
-  });
-
-  p = p.catch(function (err) {
-    console.error(err);
-    res.status(503).json({
-      message: 'Could not shut down all ' + workerType,
-    });
-  });
-
-  return p;
-
-});
-
-api.declare({
-  method: 'post',
-  route: '/shutdown/every/single/ec2/instance/managed/by/this/provisioner',
-  name: 'shutdownEverySingleEc2InstanceManagedByThisProvisioner',
-  title: 'Shutdown Every Single Ec2 Instance Managed By This Provisioner',
-  scopes: [
-    [
-      'aws-provisioner:all-stop',
-      'aws-provisioner:aws',
-    ],
-  ],
-  description: [
-    'WARNING: YOU ALMOST CERTAINLY DO NOT WANT TO USE THIS ',
-    'Shut down every single EC2 instance managed by this provisioner. ',
-    'This means every single last one.  You probably don\'t want to use ',
-    'this method, which is why it has an obnoxious name.  Don\'t even try ',
-    'to claim you didn\'t know what this method does!',
-    '',
-    '**This API end-point is experimental and may be subject to change without warning.**',
-  ].join('\n'),
-}, function (req, res) {
-
-  debug('SOMEONE IS TURNING EVERYTHING OFF');
-
-  // Note that by telling the rouge killer
-  var p = this.awsManager.rougeKiller([]);
-
-  p = p.then(function () {
-    res.reply({
-      outcome: true,
-      message: 'You just turned absolutely everything off.  Feel the power!',
-    });
-  });
-
-  p = p.catch(function (err) {
-    console.error(err, err.stack);
-    res.status(503).json({
-      message: 'Could not shut down everything',
-    });
-  });
-
-  return p;
-
-});
-
-api.declare({
-  method: 'get',
-  route: '/aws-state/',
-  name: 'awsState',
-  title: 'Get AWS State for all worker types',
-  scopes: ['aws-provisioner:view-aws-state'],
-  description: [
-    'Documented later...',
-    '',
-    '**Warning** this api end-point is **not stable**',
-  ].join('\n'),
-}, function (req, res) {
-  res.reply(this.awsManager.emulateOldStateFormat());
+  var outcome;
+  try {
+    outcome = worker.testLaunchSpecs();
+  } catch (err) {
+    outcome = [];
+    if (err.reasons) {
+      err.reasons.forEach(function (e) {
+        console.error(e, e.stack);
+        outcome.push({error: e, stack: e.stack});
+      });
+    }
+  } finally {
+    return res.reply(outcome);
+  }
 });
 
 api.declare({
@@ -666,9 +544,10 @@ api.declare({
   title: 'Get AWS State for a worker type',
   scopes: ['aws-provisioner:view-worker-type:<workerType>'],
   description: [
-    'Documented later...',
-    '',
-    '**Warning** this api end-point is **not stable**',
+    'Return the state of a given workertype as stored by the provisioner. ',
+    'This state is stored as three lists: 1 for all instances, 1 for requests',
+    'which show in the ec2 api and 1 list for those only tracked internally',
+    'in the provisioner.',
   ].join('\n'),
 }, async function (req, res) {
   var workerType = req.params.workerType;

--- a/lib/secret.js
+++ b/lib/secret.js
@@ -1,7 +1,7 @@
 'use strict';
-var base = require('taskcluster-base');
+let base = require('taskcluster-base');
 
-var Secret = base.Entity.configure({
+let Secret = base.Entity.configure({
   version: 1,
 
   partitionKey: base.Entity.keys.StringKey('token'),

--- a/lib/watchdog.js
+++ b/lib/watchdog.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var util = require('util');
-var events = require('events');
-var debug = require('debug')('watchdog');
+let util = require('util');
+let events = require('events');
+let debug = require('debug')('watchdog');
 
 /**
  * This is a watch dog timer.  Think of it as a ticking
@@ -12,11 +12,11 @@ var debug = require('debug')('watchdog');
  * timer is allowed to expire
  */
 function WatchDog (maxTime) {
-  var that = this;
+  let that = this;
   this.maxTime = maxTime;
   events.EventEmitter.call(this);
   this.action = function () {
-    var error = new Error('Watchdog expired!');
+    let error = new Error('Watchdog expired!');
     // A better way to make this mandatory?
     if (that.listeners('expired').length > 0) {
       debug('emitting expired event');
@@ -57,7 +57,7 @@ WatchDog.prototype.stop = function () {
  * keeps running
  */
 WatchDog.prototype.touch = function () {
-  var oldWD = this.__watchDog;
+  let oldWD = this.__watchDog;
   this.__watchDog = setTimeout(this.action, this.maxTime * 1000);
   clearTimeout(oldWD);
   this.emit('touched');

--- a/lib/worker-type.js
+++ b/lib/worker-type.js
@@ -803,4 +803,4 @@ WorkerType.prototype.determineSpotBids = function (managedRegions, pricing, chan
   return spotBids;
 };
 
-exports.WorkerType = WorkerType;
+module.exports = WorkerType;

--- a/test/manageworkertype_test.js
+++ b/test/manageworkertype_test.js
@@ -44,8 +44,9 @@ describe('provisioner worker type api', () => {
     assume(wType.maxCapacity).equals(15);
   });
 
-  it('should be able to remove a worker', async () => {
+  it('should be able to remove a worker (idempotent)', async () => {
     debug('### Remove workerType');
+    await helper.awsProvisioner.removeWorkerType(id);
     await helper.awsProvisioner.removeWorkerType(id);
 
     debug('### Try to load workerType');

--- a/test/secrets_test.js
+++ b/test/secrets_test.js
@@ -36,7 +36,6 @@ describe('secrets api', () => {
 
     try {
       await helper.awsProvisioner.getSecret(token);
-      throw new Error('Expected and error');
     } catch(err) {
       assume(err.statusCode).equals(404);
     }

--- a/test/workertype_test.js
+++ b/test/workertype_test.js
@@ -1,6 +1,6 @@
 'use strict';
 var base = require('taskcluster-base');
-var data = require('../lib/data.js');
+var workerType = require('../lib/worker-type');
 var slugid = require('slugid');
 var mock = require('./mock-workers');
 
@@ -34,7 +34,7 @@ var provisionerId = cfg.get('provisioner:id');
   maxPendingPoints: cfg.get('influx:maxPendingPoints'),
 });*/
 
-var subject = data.WorkerType.setup({
+var subject = workerType.setup({
   table: cfg.get('provisioner:workerTypeTableName'),
   credentials: cfg.get('azure'),
   context: {


### PR DESCRIPTION
A whole bunch of cleanups, and also the first stage in storing the state of each worker type in a list.  I really would prefer to maintain the structure of the AWS API returns, but when we have a limit for how large an entity can be, I didn't want to waste space.  I can't quite remember how large the JSONType can be, what do you think about storing it in this way?  I'm not sure if we can break it down further in a meaningful way, so I hope that Entities can handle this.

For the time being, I'm leaving the old aws state in there because i need to update the tools site as well.  The plan is deploy this then update the tools ui to consume this then update the the server to delete the legacy code around having an aws manager in the api server.