### PR TITLE
load worker type entities individually instead of in a scan

### DIFF
--- a/lib/provision.js
+++ b/lib/provision.js
@@ -158,10 +158,10 @@ Provisioner.prototype.stop = function () {
  * Run provisioners for all known worker types once
  */
 Provisioner.prototype.runAllProvisionersOnce = async function () {
-  let workerTypes;
+  let workerNames;
   try {
-    workerTypes = await this.WorkerType.loadAll();
-    debug('loaded worker types');
+    workerNames = await this.WorkerType.listWorkerTypes();
+    debug('loaded worker type names');
   } catch (err) {
     debug('error loading worker types');
     debug(err);
@@ -183,8 +183,6 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
     throw err;
   }
 
-  let workerNames = workerTypes.map(w => w.workerType);
-
   try {
     await this.awsManager.rougeKiller(workerNames);
     debug('ran rouge killer');
@@ -192,7 +190,7 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
     debug('ran zombie killer');
     await this.awsManager.ensureTags();
     debug('ensured resource tagging');
-    for (let name of workerNames) {
+      for (let name of workerNames) {
       await this.awsManager.createKeyPair(name);
     }
     debug('all key pairs created');
@@ -209,8 +207,21 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
 
   let forSpawning = [];
 
-  for (let worker of workerTypes) {
+  for (let workerName of workerNames) {
     let change;
+    let worker;
+    try {
+      worker = await this.WorkerType.load({workerType: workerName});
+      debug('loaded workerType object for %s', workerName);
+    } catch (loadErr) {
+      debug('error loading %s workertype definition', workerName);
+      debug(loadErr);
+      if (loadErr.stack) {
+        debug(loadErr.stack);
+      }
+      throw loadErr;
+    }
+
     try {
       change = await this.changeForType(worker);
       debug('type %s had a change of %d', worker.workerType, change);
@@ -273,9 +284,7 @@ Provisioner.prototype.runAllProvisionersOnce = async function () {
 
   // We want to shuffle up the bids so that we don't prioritize
   // any particular worker type
-  debug('START FOR SPAWNING');
-  debug(JSON.stringify(forSpawning, null, 2));
-  debug('END FOR SPAWNING');
+  debug('\nSTART FOR SPAWNING\n%s\nEND FOR SPAWNING', JSON.stringify(forSpawning, null, 2));
   forSpawning = shuffle.knuthShuffle(forSpawning);
 
   while (forSpawning.length > 0 && attemptsLeft-- > 0) {


### PR DESCRIPTION
I'm wondering if there's something happening in the scan operation while building the list of worker entities.  This changes things to make it load the list of strings, which are much simpler, then load each workerType just before it is about to have its bids determined.

There is a loss of atomicity in the load operations here now.  There are two cases which we care about: creating and deleting a worker type.  The time delta between loading the list of names and loading the definitions is only important for these operations and only for the time period between the two operations.  The majority of code between listing the names and loading the definitions is not too large, just the time to lead the remaining entities.  There are no ec2 api calls until all workerType definitions are loaded.

When creating a workerType between the list() and load() call, we simply ignore that worker type for that given iteration.  The iteration is marked as success and the next iteration is the first one with the new worker type.

When deleting a workerType between the list() and load() call, we will try to load the workerType which will fail.  The ResourceNotFound exception will cause that workerType to fail to run its provisioning logic and will prematurely end that iteration, marking it as failure.  This will not kill the provisioner as we need >10? consecutive failing iterations to kill things.  The next iteration will be able to complete as designed.

This is more a diagnostic than a desired change... I'm just trying to reduce complexity where I can.  Building a list of strings is less complex that building a list of entities.