### PR TITLE
return existing bids instead of an empty list

### DIFF
--- a/lib/worker-type.js
+++ b/lib/worker-type.js
@@ -794,7 +794,7 @@ WorkerType.prototype.determineSpotBids = function (managedRegions, pricing, chan
     } else {
       debug('WorkerType %s is exceeding its max price of %d with %d',
             this.workerType, this.maxPrice, cheapestPrice);
-      return [];
+      return spotBids;
     }
 
     // This is a sanity check to prevent a screw up where we theoretically
@@ -804,7 +804,7 @@ WorkerType.prototype.determineSpotBids = function (managedRegions, pricing, chan
     // change to the provisioner is a demonstration of our knowledge of that.
     if (cheapestBid > 10) {
       debug('[alert-operator] %s spot bid is exceptionally high...', this.workerType);
-      return [];
+      return spotBids;
     }
   }
   /* eslint-enable no-loop-func */


### PR DESCRIPTION
Instead of returning no bids, we know that at this stage that the bids already in spotBids are OK since we didn't hit either of the max price checks.  Instead of ignoring those bids, let's submit them and let the next iteration handle the bids which couldn't get created.

I think this is slightly better behaviour, but I still appreciate you jumping in last night to get a fix out there :)