### PR TITLE
Fix SSH Key rotation so that we change the KeyPair with a new awsInstancePubkey setting

### DIFF
--- a/bin/provisioner.js
+++ b/bin/provisioner.js
@@ -59,6 +59,7 @@ let launch = function (profile) {
       keyPrefix: keyPrefix,
       provisionerId: provisionerId,
       provisionerBaseUrl: provisionerBaseUrl,
+      pubKey: pubKey,
     },
   });
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -37,6 +37,7 @@ let launch = async function (profile) {
   });
 
   let keyPrefix = cfg.get('provisioner:awsKeyPrefix');
+  let pubKey = cfg.get('provisioner:awsInstancePubkey');
   let provisionerId = cfg.get('provisioner:id');
   let provisionerBaseUrl = cfg.get('server:publicUrl') + '/v1';
 
@@ -73,6 +74,7 @@ let launch = async function (profile) {
       keyPrefix: keyPrefix,
       provisionerId: provisionerId,
       provisionerBaseUrl: provisionerBaseUrl,
+      pubKey: pubKey,
     },
     //account: cfg.get('azure:accountName'),
     //credentials: cfg.get('taskcluster:credentials'),
@@ -135,6 +137,7 @@ let launch = async function (profile) {
       ec2: ec2,
       publisher: publisher,
       keyPrefix: keyPrefix,
+      pubKey: pubKey,
       provisionerId: provisionerId,
       provisionerBaseUrl: provisionerBaseUrl,
       reportInstanceStarted: reportInstanceStarted,

--- a/lib/aws-manager.js
+++ b/lib/aws-manager.js
@@ -4,6 +4,7 @@ let debug = require('debug')('aws-provisioner:aws-manager');
 let shuffle = require('knuth-shuffle');
 let taskcluster = require('taskcluster-client');
 let series = require('./influx-series');
+let keyPairs = require('./key-pairs');
 
 const MAX_ITERATIONS_FOR_STATE_RESOLUTION = 20;
 
@@ -671,7 +672,7 @@ class AwsManager {
     for (let region of this.ec2.regions) {
       for (let reservation of instanceState[region].Reservations) {
         for (let instance of reservation.Instances) {
-          let workerType = instance.KeyName.substr(this.keyPrefix.length);
+          let workerType = this.parseKeyPairName(instance.KeyName).workerType;
           // XXX let filtered = objFilter(instance, this.filters.instance);
           let filtered = instance;
           filtered.Region = region;
@@ -681,7 +682,7 @@ class AwsManager {
       }
 
       for (let request of spotReqs[region]) {
-        let workerType = request.LaunchSpecification.KeyName.substr(this.keyPrefix.length);
+        let workerType = this.parseKeyPairName(request.LaunchSpecification.KeyName).workerType;
         // XXX let filtered = objFilter(request, this.filters.spotReq);
         let filtered = request;
         filtered.Region = region;
@@ -1081,6 +1082,27 @@ class AwsManager {
   }
 
   /**
+   * wrapper for brevity
+   */
+  createPubKeyHash () {
+    return keyPairs.createPubKeyHash(this.pubKey);
+  }
+
+  /**
+   * wrapper for brevity
+   */
+  createKeyPairName (workerName) {
+    return keyPairs.createKeyPairName(this.keyPrefix, this.pubKey, workerName);
+  }
+
+  /**
+   * wrapper for brevity
+   */
+  parseKeyPairName (name) {
+    return keyPairs.parseKeyPairName(name);
+  }
+
+  /**
    * We use KeyPair names to determine ownership and workerType
    * in the EC2 world because we can't tag SpotRequests until they've
    * mutated into Instances.  This sucks and all, but hey, what else
@@ -1097,9 +1119,10 @@ class AwsManager {
    */
   async createKeyPair (workerName) {
     assert(workerName);
-    let keyName = this.keyPrefix + workerName;
+    
+    let keyName = this.createKeyPairName(workerName);
 
-    if (this.__knownKeyPairs.includes(workerName)) {
+    if (this.__knownKeyPairs.includes(keyName)) {
       // Short circuit checking for a key but return
       // a promise so this cache is invisible to the
       // calling function from a non-cached instance
@@ -1135,7 +1158,7 @@ class AwsManager {
       }
     }
 
-    this.__knownKeyPairs.push(workerName);
+    this.__knownKeyPairs.push(keyName);
   }
 
   /**
@@ -1145,7 +1168,8 @@ class AwsManager {
    */
   async deleteKeyPair (workerName) {
     assert(workerName);
-    let keyName = this.keyPrefix + workerName;
+
+    let keyName = this.createKeyPairName(workerName);
 
     let res = await this.ec2.describeKeyPairs({
       Filters: [
@@ -1174,7 +1198,7 @@ class AwsManager {
       }
     }
 
-    this.__knownKeyPairs = this.__knownKeyPairs.filter(k => k !== workerName);
+    this.__knownKeyPairs = this.__knownKeyPairs.filter(k => k !== keyName);
   }
 
   /**

--- a/lib/key-pairs.js
+++ b/lib/key-pairs.js
@@ -22,9 +22,15 @@ module.exports.createPubKeyHash = function (pubKey) {
  */
 module.exports.createKeyPairName = function (prefix, pubKey, workerName) {
   assert(prefix);
+  // We want to support the case where we're still using a config setting
+  // that ends in : as it used to
+  if (prefix.charAt(prefix.length - 1) === ':') {
+    prefix = prefix.slice(0, prefix.length - 1);
+  }
+  assert(prefix.indexOf(':') === -1, 'only up to one trailing colon allowed');
   assert(pubKey);
   assert(workerName);
-  return prefix + workerName + ':' + module.exports.createPubKeyHash(pubKey);
+  return prefix + ':' + workerName + ':' + module.exports.createPubKeyHash(pubKey);
 };
 
 /**

--- a/lib/key-pairs.js
+++ b/lib/key-pairs.js
@@ -1,0 +1,51 @@
+let assert = require('assert');
+let crypto = require('crypto');
+/** 
+ * We want to ensure that the KeyPairs that we create are unique-ish-ly
+ * named so that when we rotate keys that we can ensure that new instances
+ * use the new keys.  Because we don't really care about the comment used
+ * when the pubkey was created, we just take the algorithm and the data
+ * and create a sha256 key.  Because this is not important from a security
+ * perspective, we just take the first 7 chars
+ */
+module.exports.createPubKeyHash = function (pubKey) {
+  assert(pubKey);
+  let keyData = pubKey.split(' ');
+  assert(keyData.length >= 2, 'pub key must be in a valid format');
+  keyData = keyData[0] + ' ' + keyData[1];
+  keyData = crypto.createHash('sha256').update(keyData).digest('hex');
+  return keyData.slice(0, 7);
+};
+
+/**
+ * Create a KeyPair name
+ */
+module.exports.createKeyPairName = function (prefix, pubKey, workerName) {
+  assert(prefix);
+  assert(pubKey);
+  assert(workerName);
+  return prefix + workerName + ':' + module.exports.createPubKeyHash(pubKey);
+};
+
+/**
+ * Parse a KeyPair name into an object with a prefix, workerType and
+ * keyHash properties on the returned object
+ */
+module.exports.parseKeyPairName = function (name) {
+  assert(name);
+  let parts = name.split(':');
+  let rv = {
+    prefix: parts[0],
+    workerType: parts[1],
+  };
+
+  if (parts.length == 2) {
+    rv.keyHash = '';
+  } else if (parts.length === 3) {
+    rv.keyHash = parts[2];
+  } else {
+    throw new Error('KeyPair name is not parseable: ' + name);
+
+  }
+  return rv;
+};

--- a/lib/provision.js
+++ b/lib/provision.js
@@ -155,7 +155,7 @@ class Provisioner {
               username: this.dmsApiKey,
               password: '',
               sendImmediately: true,
-            }
+            },
           });
           console.dir(result);
         } catch (err) {
@@ -165,7 +165,6 @@ class Provisioner {
 
         // And delay for the next one so we don't overwhelm EC2
         await d();
-
 
       } while (this.__keepRunning && !process.env.PROVISION_ONCE);
       this.__watchDog.stop();

--- a/lib/routes/v1.js
+++ b/lib/routes/v1.js
@@ -109,7 +109,13 @@ api.declare({
   //       that the caller has this scopes to avoid scope elevation.
 
   try {
-    this.WorkerType.testLaunchSpecs(input, this.keyPrefix, this.provisionerId, this.provisionerBaseUrl);
+    this.WorkerType.testLaunchSpecs(
+        input,
+        this.keyPrefix,
+        this.provisionerId,
+        this.provisionerBaseUrl,
+        this.pubKey,
+        workerType);
   } catch (err) {
     // We handle invalid launch spec errors
     if (err && err.code !== 'InvalidLaunchSpecifications') {
@@ -219,7 +225,13 @@ api.declare({
   if (!req.satisfies({workerType: workerType})) { return undefined; }
 
   try {
-    this.WorkerType.testLaunchSpecs(input, this.keyPrefix, this.provisionerId, this.provisionerBaseUrl);
+    this.WorkerType.testLaunchSpecs(
+        input,
+        this.keyPrefix,
+        this.provisionerId,
+        this.provisionerBaseUrl,
+        this.pubKey,
+        workerType);
   } catch (err) {
     // We handle invalid launch spec errors
     if (err && err.code !== 'InvalidLaunchSpecifications') {

--- a/lib/worker-type.js
+++ b/lib/worker-type.js
@@ -5,6 +5,7 @@ let debug = require('debug')('aws-provisioner:WorkerType');
 let debugMigrate = require('debug')('aws-provisioner:migrate:WorkerType');
 let util = require('util');
 let slugid = require('slugid');
+let keyPairs = require('./key-pairs');
 
 const KEY_CONST = 'worker-type';
 
@@ -190,7 +191,7 @@ WorkerType = WorkerType.configure({
 
     return newWorker;
   },
-  context: ['provisionerId', 'provisionerBaseUrl', 'keyPrefix'],
+  context: ['provisionerId', 'provisionerBaseUrl', 'keyPrefix', 'pubKey'],
 });
 
 /**
@@ -325,7 +326,7 @@ WorkerType.prototype.capacityOfType = function (instanceType) {
 WorkerType.prototype.createLaunchSpec = function (bid) {
   assert(bid);
   return WorkerType.createLaunchSpec(bid,
-      this, this.keyPrefix, this.provisionerId, this.provisionerBaseUrl);
+      this, this.keyPrefix, this.provisionerId, this.provisionerBaseUrl, this.pubKey, this.workerType);
 };
 
 /**
@@ -334,7 +335,13 @@ WorkerType.prototype.createLaunchSpec = function (bid) {
  * a dictionary of all the launch specs!
  */
 WorkerType.prototype.testLaunchSpecs = function () {
-  return WorkerType.testLaunchSpecs(this, this.keyPrefix, this.provisionerId, this.provisionerBaseUrl);
+  return WorkerType.testLaunchSpecs(
+      this,
+      this.keyPrefix,
+      this.provisionerId,
+      this.provisionerBaseUrl,
+      this.pubKey,
+      this.workerType);
 };
 
 /**
@@ -343,7 +350,7 @@ WorkerType.prototype.testLaunchSpecs = function () {
  * so that we can create and test launch specifications before inserting
  * them into Azure.
  */
-WorkerType.createLaunchSpec = function (bid, worker, keyPrefix, provisionerId, provisionerBaseUrl) {
+WorkerType.createLaunchSpec = function (bid, worker, keyPrefix, provisionerId, provisionerBaseUrl, pubKey, workerName) {
   // These are the keys which are only applicable to a given region.
   assert(bid, 'must specify a bid');
   assert(bid.region, 'bid must specify a region');
@@ -353,6 +360,8 @@ WorkerType.createLaunchSpec = function (bid, worker, keyPrefix, provisionerId, p
   assert(keyPrefix, 'must provide key prefix');
   assert(provisionerId, 'must provide provisioner id');
   assert(provisionerBaseUrl, 'must provide provisioner base url');
+  assert(pubKey, 'must provide public key data');
+  assert(workerName, 'must provide a worker name');
 
   // Find the region objects, assert if region is not found
   let selectedRegion = {};
@@ -457,7 +466,7 @@ WorkerType.createLaunchSpec = function (bid, worker, keyPrefix, provisionerId, p
   }
 
   // Set the KeyPair, InstanceType and availability zone correctly
-  config.launchSpec.KeyName = keyPrefix + worker.workerType;
+  config.launchSpec.KeyName = keyPairs.createKeyPairName(keyPrefix, pubKey, workerName);
   config.launchSpec.InstanceType = bid.type;
 
   // We want to make sure that we overwrite the least that we need
@@ -561,11 +570,13 @@ WorkerType.createLaunchSpec = function (bid, worker, keyPrefix, provisionerId, p
  * function will throw if there is an error found or will return
  * a dictionary of all the launch specs!
  */
-WorkerType.testLaunchSpecs = function (worker, keyPrefix, provisionerId, provisionerBaseUrl) {
+WorkerType.testLaunchSpecs = function (worker, keyPrefix, provisionerId, provisionerBaseUrl, pubKey, workerName) {
   assert(worker);
   assert(keyPrefix);
   assert(provisionerId);
   assert(provisionerBaseUrl);
+  assert(pubKey);
+  assert(workerName);
   let errors = [];
   let launchSpecs = {};
   for (let r of worker.regions) {
@@ -581,7 +592,14 @@ WorkerType.testLaunchSpecs = function (worker, keyPrefix, provisionerId, provisi
           type: type,
           zone: 'fakezone1',
         };
-        let x = WorkerType.createLaunchSpec(bid, worker, keyPrefix, provisionerId, provisionerBaseUrl);
+        let x = WorkerType.createLaunchSpec(
+            bid,
+            worker,
+            keyPrefix,
+            provisionerId,
+            provisionerBaseUrl,
+            pubKey,
+            workerName);
         launchSpecs[region][type] = x;
       } catch (e) {
         errors.push(e);
@@ -592,6 +610,7 @@ WorkerType.testLaunchSpecs = function (worker, keyPrefix, provisionerId, provisi
     let err = new Error('Launch specifications are invalid');
     err.code = 'InvalidLaunchSpecifications';
     err.reasons = errors;
+    debug(errors.map(x => x.stack || x).join('\n'));
     throw err;
   }
   return launchSpecs;

--- a/test/workertype_test.js
+++ b/test/workertype_test.js
@@ -22,7 +22,7 @@ var cfg = base.config({
 });
 
 var keyPrefix = cfg.get('provisioner:awsKeyPrefix');
-//var pubKey = cfg.get('provisioner:awsInstancePubkey');
+var pubKey = cfg.get('provisioner:awsInstancePubkey');
 var provisionerId = cfg.get('provisioner:id');
 //var maxInstanceLife = cfg.get('provisioner:maxInstanceLife');
 
@@ -48,6 +48,7 @@ var subject = workerType.setup({
     keyPrefix: keyPrefix,
     provisionerId: provisionerId,
     provisionerBaseUrl: cfg.get('server:publicUrl'),
+    pubKey: pubKey,
   },
   //account: cfg.get('azure:accountName'),
   //credentials: cfg.get('taskcluster:credentials'),
@@ -88,7 +89,7 @@ describe('worker type', function () {
         instanceTypes: [makeInstanceType({instanceType: 'c3.small'}), makeInstanceType({instanceType: 'c3.medium'})],
         regions: [makeRegion({region: 'us-west-1'}), makeRegion({region: 'eu-central-1'})],
       });
-      subject.testLaunchSpecs(wType, 'keyPrefix', 'provisionerId', 'url');
+      subject.testLaunchSpecs(wType, 'keyPrefix', 'provisionerId', 'url', 'ssh-rsa fakepubkey comment', 'workerName');
     });
 
     function shouldThrow (wType) {
@@ -173,7 +174,7 @@ describe('worker type', function () {
         region: 'us-west-1',
         type: 'c3.small',
         zone: 'fakezone',
-      }, wType, 'keyPrefix', 'provisionerId', 'url').launchSpec;
+      }, wType, 'keyPrefix', 'provisionerId', 'url', 'ssh-rsa fakepubkey comment', 'name').launchSpec;
       var userData = JSON.parse(new Buffer(launchSpec.UserData, 'base64').toString());
 
       userData.capacity.should.equal(1);


### PR DESCRIPTION
Basically add a sha256[0:7] of the public key to the KeyPair and parse that out when enumerating keys.
This also factors out the KeyPair parsing/generating stuff into nice functions.  We can't delete
old keys until we know that there are no instances using the old KeyPair.  I guess we could go through
all instances and make sure that all keys which start with the prefix but don't have a running instance
or the ssh pubkey hash of the current pubkey are deleted... not too important though