### PR TITLE
Refuse to allow insertion of bad workertype definitions

### DIFF
--- a/lib/aws-manager.js
+++ b/lib/aws-manager.js
@@ -1037,12 +1037,20 @@ class AwsManager {
     assert(this.__availableAZ[bid.region].includes(bid.zone),
         'will not submit spot request in an unavailable az');
 
-    let spotRequest = await this.ec2.requestSpotInstances.inRegion(bid.region, {
-      InstanceCount: 1,
-      Type: 'one-time',
-      LaunchSpecification: launchInfo.launchSpec,
-      SpotPrice: bid.price.toString(),
-    });
+    try {
+      let spotRequest = await this.ec2.requestSpotInstances.inRegion(bid.region, {
+        InstanceCount: 1,
+        Type: 'one-time',
+        LaunchSpecification: launchInfo.launchSpec,
+        SpotPrice: bid.price.toString(),
+      });
+    } catch (err) {
+      if (err.code === 'InvalidAMIID.NotFound') {
+        debug(err.message + 'in ' + bid.region);
+      } else {
+        throw err;
+      }
+    }
 
     let spotReq = spotRequest.SpotInstanceRequests[0];
 

--- a/lib/aws-manager.js
+++ b/lib/aws-manager.js
@@ -1037,6 +1037,8 @@ class AwsManager {
     assert(this.__availableAZ[bid.region].includes(bid.zone),
         'will not submit spot request in an unavailable az');
 
+    // We should monitor logs for something like this pattern:
+    // "The image id '[ami-33333333]' does not exist"
     try {
       let spotRequest = await this.ec2.requestSpotInstances.inRegion(bid.region, {
         InstanceCount: 1,
@@ -1046,7 +1048,7 @@ class AwsManager {
       });
     } catch (err) {
       if (err.code === 'InvalidAMIID.NotFound') {
-        debug(err.message + 'in ' + bid.region);
+        debug(err.message + ' in ' + bid.region);
       } else {
         throw err;
       }

--- a/lib/routes/v1.js
+++ b/lib/routes/v1.js
@@ -4,6 +4,7 @@ let taskcluster = require('taskcluster-client');
 let _ = require('lodash');
 let rp = require('request-promise');
 let url = require('url');
+let assert = require('assert');
 
 let SLUGID_PATTERN = /^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/;
 let GENERIC_ID_PATTERN = /^[a-zA-Z0-9-_]{1,22}$/;
@@ -59,6 +60,97 @@ let api = new base.API({
   },
 });
 
+
+/**
+ * Do nothing if a workerType is valid and should be added and throw Exception
+ * with a '.reasons' attribute with a list of reasons why it is invalid if it's
+ * not valid
+ */
+async function validateWorkerType(ctx, workerTypeName, workerType) {
+  assert(typeof ctx === 'object', 'context must be an object');
+  assert(typeof workerTypeName === 'string', 'workerTypeName must be string');
+  assert(typeof workerType === 'object', 'workerType must be object');
+
+  let reasons = [];
+
+  // First let's ensure that the launch specs are valid and able to be
+  // generated
+  let launchSpecs = [];
+  try {
+    launchSpecs = ctx.WorkerType.testLaunchSpecs(
+        workerType,
+        ctx.keyPrefix,
+        ctx.provisionerId,
+        ctx.provisionerBaseUrl,
+        ctx.pubKey,
+        workerType);
+    debug(`generated launch specifications for ${workerTypeName}`);
+  } catch (err) {
+    // We don't want to handle other things breaking, just badly formed worker
+    // types
+    debug(`could not generate launch specifications for ${workerTypeName}`);
+    if (err && err.code !== 'InvalidLaunchSpecifications') {
+      throw err;
+    }
+    reasons.concat(err.reasons);
+  }
+
+  await Promise.all(_.map(launchSpecs, async (region, regionName) => {
+    await Promise.all(_.map(region, async (type, typeName) => {
+      let launchSpec = type.launchSpec;
+      // We delete the Placement.AvailabilityZone key because we aren't don't
+      // know which AZ to test for and this shouldn't matter for these purposes
+      if (launchSpec.Placement && launchSpec.Placement.AvailabilityZone) {
+        delete launchSpec.Placement.AvailabilityZone;
+      }
+      // Next, let's check if the launch spec has valid parameters
+      try {
+        await ctx.ec2[regionName].requestSpotInstances({
+          DryRun: true,
+          InstanceCount: 1,
+          Type: 'one-time',
+          LaunchSpecification: launchSpec,
+          SpotPrice: '1', // Only since this is a DryRun:true call
+        }).promise();
+        debug(`did DryRun of requesting spot instance for ${workerTypeName}`);
+      } catch (err) {
+        if (err.code !== 'DryRunOperation') {
+          debug(`could not do a DryRun of requesting spot instance for ${workerTypeName}`);
+          reasons.push(err)
+        }
+      }
+      let images = [];
+      try {
+        images = await ctx.ec2[regionName].describeImages({
+          ImageIds: [launchSpec.ImageId],
+        }).promise();
+        if (images.data.Images.length !== 1) {
+          reasons.push(new Error(`Too many results found for ${launchSpec.ImageId}`)); 
+        }
+        let image = images.data.Images[0];
+        if (image.ImageId !== launchSpec.ImageId) {
+          reasons.push(new Error(`Image ID returned from EC2 api ${image.ImageId} does not match launch spec ${launchSpec.ImageId}`));
+        }
+        if (image.State !== 'available') {
+          reasons.push(new Error(`Image state for ${launchSpec.ImageId} must be 'available' not ${image.State}`));
+        }
+      } catch (err) {
+        reasons.push(err);
+      }
+    }));
+  }));
+
+  // Finally, let's verify that the image for this workerType exists in EC2
+
+  if (reasons.length > 0) {
+    debug('Found errors with ' + workerTypeName); 
+    let e = new Error('Refusing to create an invalid worker type');
+    e.reasons = reasons;
+    throw e
+  }
+
+}
+
 module.exports = api;
 
 api.declare({
@@ -109,33 +201,16 @@ api.declare({
   // TODO: If workerType launchSpecification specifies scopes that should be given
   //       to the workers using temporary credentials, then you should validate
   //       that the caller has this scopes to avoid scope elevation.
-
   try {
-    this.WorkerType.testLaunchSpecs(
-        input,
-        this.keyPrefix,
-        this.provisionerId,
-        this.provisionerBaseUrl,
-        this.pubKey,
-        workerType);
+    await validateWorkerType(this, workerType, input);
   } catch (err) {
-    // We handle invalid launch spec errors
-    if (err && err.code !== 'InvalidLaunchSpecifications') {
-      throw err;
-    }
-    debug('InvalidLaunchSpecifications!');
-    if (err.reasons) {
-      for (let reason of err.reasons) {
-        debug(reason);
-      }
-    }
     res.status(400).json({
-      message: 'Invalid launchSpecification',
+      message: 'Invalid workerType',
       error: {
         reasons: err.reasons,
-      },
+      }
     });
-    return;
+    return
   }
 
   // Create workerType
@@ -227,30 +302,15 @@ api.declare({
   if (!req.satisfies({workerType: workerType})) { return undefined; }
 
   try {
-    this.WorkerType.testLaunchSpecs(
-        input,
-        this.keyPrefix,
-        this.provisionerId,
-        this.provisionerBaseUrl,
-        this.pubKey,
-        workerType);
+    await validateWorkerType(this, workerType, input);
   } catch (err) {
-    // We handle invalid launch spec errors
-    if (err && err.code !== 'InvalidLaunchSpecifications') {
-      throw err;
-    }
-    debug('InvalidLaunchSpecifications!');
-    if (err.reasons) {
-      for (let reason of err.reasons) {
-        debug(reason);
-      }
-    }
-    return res.status(400).json({
-      message: 'Invalid launchSpecification',
+    res.status(400).json({
+      message: 'Invalid workerType',
       error: {
         reasons: err.reasons,
-      },
+      }
     });
+    return
   }
 
   let wType = await this.WorkerType.load({workerType: workerType});


### PR DESCRIPTION
@jonasfj how do you feel about this?  I should still probably put a try/catch around the requestSpotInstances and check if the failure to request a spot instance is because of a bad ami id, and if so, ignore the error and maybe send a pulse message or something?

fyi @petemoore and grenade, but I don't know his github.