### PR TITLE
Fix name of stalled SR ids list

### DIFF
--- a/lib/aws-manager.js
+++ b/lib/aws-manager.js
@@ -197,7 +197,7 @@ class AwsManager {
         filtered.WorkerType = workerType;
         //livingSR.push(filtered);
         if (this._spotRequestStalled(filtered)) {
-          stalledSR.push(filtered.SpotInstanceRequestId);
+          stalledSRIds.push(filtered.SpotInstanceRequestId);
         } else {
           apiState.requests.push(filtered);
         }


### PR DESCRIPTION
I hope this would fix this issue that we're seeing right now:

https://papertrailapp.com/systems/taskcluster-aws-provisioner2/events?r=641409015372623886-641412683115311123