### PR TITLE
Bug 1261024 - Align Create/Get WorkerType schemas in aws provisioner

### DIFF
--- a/schemas/create-worker-type-request.yml
+++ b/schemas/create-worker-type-request.yml
@@ -161,6 +161,7 @@ properties:
             composed of printable ASCII characters and spaces.
       additionalProperties: false
       required:
+        - region
         - launchSpec
         - secrets
         - userData

--- a/schemas/get-worker-type-response.yml
+++ b/schemas/get-worker-type-response.yml
@@ -1,5 +1,5 @@
 $schema:  http://json-schema.org/draft-04/schema#
-title:                      "Get Worker Type Request"
+title:                      "Get Worker Type Response"
 description: |
   A worker launchSpecification and required metadata
 type:                       object


### PR DESCRIPTION
This fixes `get-worker-type-response.yml` title property, and makes `region` a required property in `create-worker-type-request.yml`.