### PR TITLE
Restrict regions to allowedRegions for creating and updating worker type definitions

### DIFF
--- a/schemas/create-worker-type-request.yml
+++ b/schemas/create-worker-type-request.yml
@@ -141,6 +141,10 @@ properties:
           type: string
           description: |
             The Amazon AWS Region being configured.  Example: us-west-1
+          enum:
+            - us-west-2
+            - us-east-1
+            - us-west-1
         launchSpec:
           type: object
           description: |


### PR DESCRIPTION
I wasn't sure if there was a way to specify the values from https://github.com/taskcluster/aws-provisioner/blob/1ff88cf0f58083afd1b85904d6f57ead4eda634c/config/production.js#L11 directly here, rather than the way I've done it here (i.e. hard coding). If there is a way that we can reference the config value here, that might be nicer, so that if `allowedRegions` gets updated, or provisioner is deployed somewhere with different values, they will get picked up in the generated schemas.

The idea of this change is: a) documenting that only some regions are supported and b) ensure that only valid regions are accepted via the json interface.