### PR TITLE
bug 1272643 - start providing workerGroup and workerId value to workers

### DIFF
--- a/schemas/create-secret-request.yml
+++ b/schemas/create-secret-request.yml
@@ -8,19 +8,14 @@ properties:
     type: string
     description: |
       A string describing what the secret will be used for
+  region:
+    type: string
+    description: |
+      The region which the instance for this secret is located
   secrets:
     type: object
     description: |
       Free form object which contains the secrets stored
-  scopes:
-    type: array
-    description: |
-      List of strings which are scopes for temporary credentials to give
-      to the worker through the secret system.  Scopes must be composed of
-      printable ASCII characters and spaces.
-    items:
-      type: string
-      pattern: "^[\x20-\x7e]*$"
   token:
     type: string
     description: |
@@ -35,6 +30,6 @@ additionalProperties: false
 required:
   - workerType
   - secrets
-  - scopes
+  - region
   - token
   - expiration

--- a/schemas/get-secret-response.yml
+++ b/schemas/get-secret-response.yml
@@ -4,6 +4,14 @@ description: |
   Secrets from the provisioner
 type:                       object
 properties:
+  workerId:
+    type: string
+    description: |
+      Unique slugid which identifies this worker uniquely
+  workerGroup:
+    type: string
+    description: |
+      Name of this worker group
   data:
     type: object
     description: |
@@ -23,6 +31,9 @@ properties:
       - clientId
       - accessToken
       - certificate
+additionalProperties: false
 require:
   - data
+  - workerId
+  - workerGroup
   - credentials

--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -6,6 +6,7 @@ let _ = require('lodash');
 let rp = require('request-promise');
 let url = require('url');
 let assert = require('assert');
+let slugid = require('slugid');
 
 let SLUGID_PATTERN = /^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/;
 let GENERIC_ID_PATTERN = /^[a-zA-Z0-9-_]{1,22}$/;
@@ -603,7 +604,7 @@ api.declare({
       token: token,
       workerType: input.workerType,
       secrets: input.secrets,
-      scopes: input.scopes,
+      region: input.region,
       expiration: new Date(input.expiration),
     });
   } catch (err) {
@@ -620,7 +621,7 @@ api.declare({
       'workerType',
       'secrets',
       'token',
-      'scopes',
+      'region',
       //'expiration' weird stuff is happening here.  going to assume that
       // we should probably do some sort of Date.toISOString() comparison or something
     ].every((key) => {
@@ -665,13 +666,17 @@ api.declare({
       token: token,
     });
 
+    let workerId = slugid.v4();
+    let workerGroup = 'ec2_' + secret.region;
+
     return res.reply({
       data: secret.secrets,
-      scopes: secret.scopes,
+      workerId: workerId,
+      workerGroup: workerGroup,
       credentials: taskcluster.createTemporaryCredentials({
         scopes: [
           `assume:worker-type:${this.provisionerId}/${secret.workerType}`,
-          'assume:worker-id:*',
+          `assume:worker-id:${workerGroup}:${workerId}`,
         ],
         expiry: taskcluster.fromNow('96 hours'),
         credentials: this.credentials,

--- a/src/provision.js
+++ b/src/provision.js
@@ -340,6 +340,7 @@ class Provisioner {
     debug('creating secret %s', launchInfo.securityToken);
     await this.Secret.create({
       token: launchInfo.securityToken,
+      region: launchInfo.region,
       workerType: workerType.workerType,
       secrets: launchInfo.secrets,
       scopes: launchInfo.scopes,

--- a/src/secret.js
+++ b/src/secret.js
@@ -11,7 +11,7 @@ let Secret = base.Entity.configure({
     expiration: base.Entity.types.Date,
     workerType: base.Entity.types.String,
     secrets: base.Entity.types.JSON,
-    scopes: base.Entity.types.JSON,
+    region: base.Entity.types.String,
   },
 });
 

--- a/src/worker-type.js
+++ b/src/worker-type.js
@@ -472,7 +472,9 @@ WorkerType.createLaunchSpec = function (bid, worker, keyPrefix, provisionerId, p
     }
   }
 
-  let config = {};
+  let config = {
+    region: bid.region,
+  };
 
   // Do the cascading overwrites of the object things
   for (let x of ['launchSpec', 'userData', 'secrets']) {

--- a/test-src/secrets_test.js
+++ b/test-src/secrets_test.js
@@ -8,13 +8,13 @@ describe('secrets api', () => {
   var token = slugid.v4();
   var secretToAdd = {
     workerType: 'workerType',
+    region: 'us-west-1',
     secrets: {
       key1: true,
       key2: 123,
       key3: 'sample',
       key4: {a: 123},
     },
-    scopes: ['ascope'],
     token: token,
     expiration: taskcluster.fromNow('1 day'),
   };
@@ -26,6 +26,9 @@ describe('secrets api', () => {
 
   it('should be able to load a secret', async () => {
     var loadedSecret = await helper.awsProvisioner.getSecret(token);
+    console.log(JSON.stringify(loadedSecret, null, 2));
+    assume(loadedSecret.workerId).is.ok();
+    assume(loadedSecret.workerGroup).is.ok();
     assume(loadedSecret.data).to.eql(secretToAdd.secrets);
   });
 


### PR DESCRIPTION
The only open question here is whether to make the workerGroup be the provisionerId or e.g. ec2_us-west-1.  I don't have a strong preference one way or the other, but including the region is 90% of the content of this patch, as it requires an update to the secret entity.
