### PR TITLE
Bug 1244656 - Long live terminateAllInstancesOfWorkerType and shutdownEverySingleEc2InstanceManagedByThisProvisioner

### DIFF
--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -1099,3 +1099,93 @@ api.declare({
     lastCheckedIn: snitch.checked_in_at,
   });
 });
+
+api.declare({
+  method: 'post',
+  route: '/worker-type/:workerType/terminate-all-instances',
+  name: 'terminateAllInstancesOfWorkerType',
+  title: 'Shutdown Every Ec2 Instance of this Worker Type',
+  stability:  base.API.stability.experimental,
+  scopes: [
+    [
+      'aws-provisioner:terminate-all-worker-type:<workerType>',
+    ],
+  ],
+  description: [
+    'WARNING: YOU ALMOST CERTAINLY DO NOT WANT TO USE THIS ',
+    'Shut down every single EC2 instance associated with this workerType. ',
+    'This means every single last one.  You probably don\'t want to use ',
+    'this method, which is why it has an obnoxious name.  Don\'t even try ',
+    'to claim you didn\'t know what this method does!',
+    '',
+    '**This API end-point is experimental and may be subject to change without warning.**',
+  ].join('\n'),
+}, function (req, res) {
+  var workerType = req.params.workerType;
+
+  debug('SOMEONE IS TURNING OFF ALL ' + workerType + ' WORKERS');
+
+  var p = this.awsManager.killByName(workerType);
+
+  p = p.then(function () {
+    res.reply({
+      outcome: true,
+      message: 'You just terminated all ' + workerType + ' workers.  Feel the power!',
+    });
+  });
+
+  p = p.catch(function (err) {
+    console.error(err);
+    res.status(503).json({
+      message: 'Could not terminate all ' + workerType + ' workers.',
+    });
+  });
+
+  return p;
+
+});
+
+api.declare({
+  method: 'post',
+  route: '/shutdown/every/single/ec2/instance/managed/by/this/provisioner',
+  name: 'shutdownEverySingleEc2InstanceManagedByThisProvisioner',
+  title: 'Shutdown Every Single Ec2 Instance Managed By This Provisioner',
+  stability:  base.API.stability.experimental,
+  scopes: [
+    [
+      'aws-provisioner:terminate-all-worker-type:*',
+    ],
+  ],
+  description: [
+    'WARNING: YOU ALMOST CERTAINLY DO NOT WANT TO USE THIS ',
+    'Shut down every single EC2 instance managed by this provisioner. ',
+    'This means every single last one.  You probably don\'t want to use ',
+    'this method, which is why it has an obnoxious name.  Don\'t even try ',
+    'to claim you didn\'t know what this method does!',
+    '',
+    '**This API end-point is experimental and may be subject to change without warning.**',
+  ].join('\n'),
+}, function (req, res) {
+
+  debug('SOMEONE IS TURNING EVERYTHING OFF');
+
+  // Note that by telling the rogue killer
+  var p = this.awsManager.rogueKiller([]);
+
+  p = p.then(function () {
+    res.reply({
+      outcome: true,
+      message: 'You just turned absolutely everything off.  Feel the power!',
+    });
+  });
+
+  p = p.catch(function (err) {
+    console.error(err, err.stack);
+    res.status(503).json({
+      message: 'Could not shut down everything',
+    });
+  });
+
+  return p;
+
+});

--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -1120,29 +1120,23 @@ api.declare({
     '',
     '**This API end-point is experimental and may be subject to change without warning.**',
   ].join('\n'),
-}, function (req, res) {
-  var workerType = req.params.workerType;
+}, async function (req, res) {
+  let workerType = req.params.workerType;
 
   debug('SOMEONE IS TURNING OFF ALL ' + workerType + ' WORKERS');
 
-  var p = this.awsManager.killByName(workerType);
-
-  p = p.then(function () {
-    res.reply({
+  try {
+    await this.awsManager.killByName(workerType);
+    return res.reply({
       outcome: true,
       message: 'You just terminated all ' + workerType + ' workers.  Feel the power!',
     });
-  });
-
-  p = p.catch(function (err) {
-    console.error(err);
+  } catch (err) {
+    debug(err.stack || err);
     res.status(503).json({
       message: 'Could not terminate all ' + workerType + ' workers.',
     });
-  });
-
-  return p;
-
+  }
 });
 
 api.declare({
@@ -1165,27 +1159,21 @@ api.declare({
     '',
     '**This API end-point is experimental and may be subject to change without warning.**',
   ].join('\n'),
-}, function (req, res) {
+}, async function (req, res) {
 
   debug('SOMEONE IS TURNING EVERYTHING OFF');
 
   // Note that by telling the rogue killer
-  var p = this.awsManager.rogueKiller([]);
-
-  p = p.then(function () {
-    res.reply({
+  try {
+    await this.awsManager.rogueKiller([]);
+    return res.reply({
       outcome: true,
       message: 'You just turned absolutely everything off.  Feel the power!',
     });
-  });
-
-  p = p.catch(function (err) {
-    console.error(err, err.stack);
-    res.status(503).json({
+  } catch (err) {
+    debug(err.stack || err);
+    return res.status(503).json({
       message: 'Could not shut down everything',
     });
-  });
-
-  return p;
-
+  }
 });

--- a/src/aws-manager.js
+++ b/src/aws-manager.js
@@ -1172,23 +1172,23 @@ class AwsManager {
   }
 
   /**
-   * Rouge Killer.  A rouge is an instance that has a KeyPair name that belongs
+   * Rogue Killer.  A rogue is an instance that has a KeyPair name that belongs
    * to this provisioner but is not present in the list of workerNames
    * provided.  We can also use this to shut down all instances of everything
    * if we just pass an empty list of workers which will say to this function
-   * that all workerTypes are rouge.  Sneaky, huh?
+   * that all workerTypes are rogue.  Sneaky, huh?
    */
-  async rougeKiller(configuredWorkers) {
+  async rogueKiller(configuredWorkers) {
     assert(configuredWorkers);
     let workersKnowByAws = this.knownWorkerTypes();
 
     let unconfiguredWorkerNames = workersKnowByAws.filter(n => !_.includes(configuredWorkers, n));
 
     for (let name of unconfiguredWorkerNames) {
-      debug('killing rouge %s', name);
+      debug('killing rogue %s', name);
       await this.deleteKeyPair(name);
       await this.killByName(name);
-      debug('killed rouge %s', name);
+      debug('killed rogue %s', name);
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -138,8 +138,8 @@ let load = base.loader({
   },
 
   api: {
-    requires: ['cfg', 'WorkerType', 'AmiSet', 'Secret', 'ec2', 'stateContainer', 'validator', 'publisher', 'influx'],
-    setup: async ({cfg, WorkerType, AmiSet, Secret, ec2, stateContainer, validator, publisher, influx}) => {
+    requires: ['cfg', 'awsManager', 'WorkerType', 'AmiSet', 'Secret', 'ec2', 'stateContainer', 'validator', 'publisher', 'influx'],
+    setup: async ({cfg, awsManager, WorkerType, AmiSet, Secret, ec2, stateContainer, validator, publisher, influx}) => {
 
       let reportInstanceStarted = series.instanceStarted.reporter(influx);
 
@@ -159,6 +159,7 @@ let load = base.loader({
           iterationSnitch: cfg.deadmanssnitch.iterationSnitch,
           ec2: ec2,
           stateContainer: stateContainer,
+          awsManager: awsManager,
         },
         validator: validator,
         authBaseUrl: cfg.taskcluster.authBaseUrl,

--- a/src/provision.js
+++ b/src/provision.js
@@ -221,8 +221,8 @@ class Provisioner {
     try {
       await this.awsManager.ensureTags();
       debug('ensured resource tagging');
-      await this.awsManager.rougeKiller(workerNames);
-      debug('ran rouge killer');
+      await this.awsManager.rogueKiller(workerNames);
+      debug('ran rogue killer');
       await this.awsManager.zombieKiller();
       debug('ran zombie killer');
       for (let name of workerNames) {

--- a/src/provision.js
+++ b/src/provision.js
@@ -24,8 +24,7 @@ class Provisioner {
    */
   constructor(cfg) {
     assert(typeof cfg === 'object');
-    // We should have an AwsManager
-    assert(cfg.awsManager);
+    assert(cfg.awsManager); //  eslint-disable-line no-alert, quotes, semi
     this.awsManager = cfg.awsManager;
 
     // We should have a WorkerType Entity


### PR DESCRIPTION
That should do it!

Brought to life from the [graveyard](https://github.com/taskcluster/aws-provisioner/blob/cf460f8846df79833b2accd44b15f89a21c01e8c/lib/routes/v1.js#L575-L663) but with slightly adjusted scopes.

Untested.

CC @djmitche @jonasfj