### PR TITLE
Only submit the first 400 requests

### DIFF
--- a/src/provision.js
+++ b/src/provision.js
@@ -296,6 +296,11 @@ class Provisioner {
     // any particular worker type
     forSpawning = shuffle.knuthShuffle(forSpawning);
 
+    // We'll only consider the first 400 requests.  Any that are dropped on the
+    // floor will be computed on the next iteration and have an equal chance of
+    // being submitted
+    forSpawning = forSpawning.slice(400);
+
     while (forSpawning.length > 0 && attemptsLeft-- > 0) {
       let toSpawn = forSpawning.shift();
       try {

--- a/src/provision.js
+++ b/src/provision.js
@@ -299,7 +299,7 @@ class Provisioner {
     // We'll only consider the first 400 requests.  Any that are dropped on the
     // floor will be computed on the next iteration and have an equal chance of
     // being submitted
-    forSpawning = forSpawning.slice(400);
+    forSpawning = forSpawning.slice(0, 400);
 
     while (forSpawning.length > 0 && attemptsLeft-- > 0) {
       let toSpawn = forSpawning.shift();


### PR DESCRIPTION
This will mean that only the first 400 bids are made.  We shuffle the list of submissions to make in a statistically random way.  Because the provsioner is not able to make any reasonable judgement about which worker types are more important, nor whether any given capacity unit is more important than any other, this is the best approach.

Limiting us to 400 instances being requested per iterations does a couple different things for us.  First, we will get status updates to the provisioner ui more quickly.  We'll also get fewer deadmans snitch warnings.

More importantly, however, is that as we work through the backlog, we can reevaluate which things should really start.  Since an unbounded list could take over an hour, we could have worked through the backlog by the time the provisioner iteration completes.