### PR TITLE
bug 1264956 check that each worker type that we're going to try to spawn is valid

### DIFF
--- a/src/aws-manager.js
+++ b/src/aws-manager.js
@@ -8,6 +8,7 @@ let series = require('./influx-series');
 let keyPairs = require('./key-pairs');
 let _ = require('lodash');
 let delayer = require('./delayer');
+let amiExists = require('./check-for-ami');
 
 const MAX_ITERATIONS_FOR_STATE_RESOLUTION = 20;
 
@@ -771,6 +772,59 @@ class AwsManager {
 
     return workerTypes;
   }
+
+  /**
+   * Decide whether the passed-in worker type is able to run
+   */
+  async workerTypeCanLaunch(worker) {
+    let canLaunch = true;
+    let reasons = []; // List of reasons why a worker type cannot launch
+
+    let launchSpecs;
+
+    // We return early here because if we can't even test launch specs,
+    // then there's no point in continuing
+    try {
+      let launchSpecs = worker.testLaunchSpecs();
+    } catch (err) {
+      canLaunch = false;
+      log.error({err}, 'cannot launch');
+      return false;
+    }
+
+    for (let r of worker.regions) {
+      let exists = await amiExists(this.ec2[r.region], r.launchSpec.ImageId);
+      // TODO: is this the right object to pass in for the ec2 value?
+      if (!exists) {
+        canLaunch = false;
+        reasons.push(new Error(`${r.launchSpec.ImageId} not found in ${r.region}`));
+      }
+
+
+      try {
+        await this.ec2[r.region].requestSpotInstance({
+          DryRun: true,
+          Type: 'one-time',
+          LaunchSpecification: launchSpecs[r.region],
+          SpotPrice: '0.1',
+        }).promise();
+      } catch (err) {
+        if (err.code !== 'DryRunOperation') {
+          canLaunch = false;
+          reasons.push(err);
+        }
+      }
+    }
+
+    if (!canLaunch) {
+      for (let x = 0; x < reasons.length; x++) {
+        log.error({err: reasons[x]}, 'cannot launch reason ' + x);
+      }
+    }
+
+    return canLaunch;
+  }
+
 
   /**
    * Count the capacity of this workerType that are in the states specified

--- a/src/provision.js
+++ b/src/provision.js
@@ -296,11 +296,6 @@ class Provisioner {
     // any particular worker type
     forSpawning = shuffle.knuthShuffle(forSpawning);
 
-    // We'll only consider the first 400 requests.  Any that are dropped on the
-    // floor will be computed on the next iteration and have an equal chance of
-    // being submitted
-    forSpawning = forSpawning.slice(0, 400);
-
     // Let's find the unique worker types in the list of requests to make
     let toSpawnWorkerTypes = _.intersection(forSpawning.map(x => x.workerType.workerType));
 
@@ -315,6 +310,11 @@ class Provisioner {
     }
 
     forSpawning = forSpawning.filter(x => disabled.indexOf(x.workerType) === -1);
+
+    // We'll only consider the first 400 requests.  Any that are dropped on the
+    // floor will be computed on the next iteration and have an equal chance of
+    // being submitted
+    forSpawning = forSpawning.slice(0, 400);
 
     while (forSpawning.length > 0 && attemptsLeft-- > 0) {
       let toSpawn = forSpawning.shift();

--- a/src/provision.js
+++ b/src/provision.js
@@ -111,7 +111,7 @@ class Provisioner {
     try {
       do {
         debug('starting iteration %d, consecutive failures %d',
-              this.__stats.runs, this.__stats.consecFail);
+            this.__stats.runs, this.__stats.consecFail);
 
         // If we don't do this, we'll have an uncaught exception
         this.__watchDog.touch();
@@ -275,7 +275,7 @@ class Provisioner {
         debug('destroying %d for %s', capToKill, worker.workerType);
         try {
           await this.awsManager.killCapacityOfWorkerType(
-                worker, capToKill, ['pending', 'spotReq']);
+              worker, capToKill, ['pending', 'spotReq']);
         } catch (killCapErr) {
           debug('[alert-operator] error running the capacity killer');
           debug(killCapErr.stack || killCapErr);
@@ -300,6 +300,21 @@ class Provisioner {
     // floor will be computed on the next iteration and have an equal chance of
     // being submitted
     forSpawning = forSpawning.slice(0, 400);
+
+    // Let's find the unique worker types in the list of requests to make
+    let toSpawnWorkerTypes = _.intersection(forSpawning.map(x => x.workerType.workerType));
+
+    let disabled = [];
+    for (let toTest of workerTypes.filter(x => toSpawnWorkerTypes.indexOf(x) !== -1)) {
+      // Consider iterating over a list where we filter out those worker types
+      // which don't have outstanding requests
+      let canLaunch = await this.awsManager.workerTypeCanLaunch(toTest);
+      if (!canLaunch) {
+        disabled.push(toTest.workerType);
+      }
+    }
+
+    forSpawning = forSpawning.filter(x => disabled.indexOf(x.workerType) === -1);
 
     while (forSpawning.length > 0 && attemptsLeft-- > 0) {
       let toSpawn = forSpawning.shift();


### PR DESCRIPTION
While we already have guards in the API against this, it does not protect against modification of the critical data fields after the fact.  There is still a possibility of something going wrong between when an iteration starts and when the submission is made, but this is a very small window and will only last for at most one iteration after the bad state occurs.

Future idea is that we update the WorkerType definition or State (or create something new) to store the list of worker types that are invalid and the reason for their invalidity.