### PR TITLE
Fix scopes for getting workerType state

### DIFF
--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -1008,6 +1008,7 @@ api.declare({
     ['aws-provisioner:view-worker-type:<workerType>'],
     ['aws-provisioner:manage-worker-type:<workerType>'],
   ],
+  deferAuth: true,
   stability:  base.API.stability.stable,
   description: [
     'Return the state of a given workertype as stored by the provisioner. ',
@@ -1019,6 +1020,10 @@ api.declare({
 }, async function (req, res) {
   let workerType;
   let workerState;
+
+  if (!req.satisfies({workerType: req.params.workerType})) {
+    return;
+  }
 
   try {
     workerType = await this.WorkerType.load({workerType: req.params.workerType});
@@ -1114,6 +1119,7 @@ api.declare({
       'aws-provisioner:terminate-all-worker-type:<workerType>',
     ],
   ],
+  deferAuth: true,
   description: [
     'WARNING: YOU ALMOST CERTAINLY DO NOT WANT TO USE THIS ',
     'Shut down every single EC2 instance associated with this workerType. ',
@@ -1125,6 +1131,10 @@ api.declare({
   ].join('\n'),
 }, async function (req, res) {
   let workerType = req.params.workerType;
+
+  if (!req.satisfies({workerType})) {
+    return;
+  }
 
   debug('SOMEONE IS TURNING OFF ALL ' + workerType + ' WORKERS');
 

--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -1004,7 +1004,10 @@ api.declare({
   route: '/state/:workerType',
   name: 'state',
   title: 'Get AWS State for a worker type',
-  scopes: [['aws-provisioner:view-worker-type:<workerType>']],
+  scopes: [
+    ['aws-provisioner:view-worker-type:<workerType>'],
+    ['aws-provisioner:manage-worker-type:<workerType>'],
+  ],
   stability:  base.API.stability.stable,
   description: [
     'Return the state of a given workertype as stored by the provisioner. ',


### PR DESCRIPTION
This should clear things up so that users can view the status for garbage workerTypes.