### PR TITLE
A different attempt on bug 1264956

### DIFF
--- a/src/provision.js
+++ b/src/provision.js
@@ -310,6 +310,13 @@ class Provisioner {
         debug('spawned a %s', toSpawn.workerType.workerType);
         await d();
       } catch (err) {
+        // Don't retry aws-sdk errors that can't be retried
+        if (err.retryable === false) {
+          // Remove all requests for given workerType, as this must mean something is wrong with the
+          // launchSpecification...
+          forSpawning = forSpawning.filter(x => x.workerType.workerType !== toSpawn.workerType.workerType);
+        }
+        
         try {
           await longD();
         } catch (longWaitErr) {


### PR DESCRIPTION
This is just a quick hack to illustrate what I mean...
@jhford, I haven't tested this... It's just an idea... based on a quick review of:
http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Response.html#error-property

Maybe, we should only filter away for the given region/workerType... As the workerType might work in other regions...