### PR TITLE
do automated retries

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -52,6 +52,7 @@ defaults:
     secretAccessKey: !env AWS_SECRET_ACCESS_KEY
     region: us-west-2
     apiVersion: 2014-01-01
+    maxRetries: 10
 
   deadmanssnitch:
     api:


### PR DESCRIPTION
Basically, this makes requestSpotInstance calls idempotent, which makes them retryable.  This means that we can use the in-built retry functionality of the AWS-SDK library.  On my work desktop talking to eu-central-1, after the initial burst of 0-retry sucesses < 0.3s, I start getting 0.5-1.5s requests and >0 retries.

this works pretty well so far.