### PR TITLE
Include internal state provisioner

### DIFF
--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -92,10 +92,6 @@ function workerTypeSummary(workerType, workerState) {
     } // note that other states are ignored
   });
 
-  workerState.requests.forEach(request => {
-    summary.requestedCapacity += capacities[request.type] || 0;
-  });
-
   return summary;
 }
 

--- a/src/aws-manager.js
+++ b/src/aws-manager.js
@@ -1488,7 +1488,6 @@ class AwsManager {
   stateForStorage(workerName) {
     let instances = [];
     let requests = [];
-    let internalTrackedRequests = [];
 
     for (let instance of this.__apiState.instances) {
       if (instance.WorkerType === workerName) {
@@ -1514,6 +1513,7 @@ class AwsManager {
           region: request.Region,
           zone: request.LaunchSpecification.Placement.AvailabilityZone,
           time: request.CreateTime,
+          visibleToEC2Api: true,
           status: request.Status.Code,
         });
       }
@@ -1521,13 +1521,14 @@ class AwsManager {
 
     for (let request of this.__internalState) {
       if (request.WorkerType === workerName) {
-        internalTrackedRequests.push({
+        requests.push({
           id: request.SpotInstanceRequestId,
           ami: request.LaunchSpecification.ImageId,
           type: request.LaunchSpecification.InstanceType,
           region: request.Region,
           zone: request.LaunchSpecification.Placement.AvailabilityZone,
           time: request.CreateTime,
+          visibleToEC2Api: false,
           status: request.Status.Code,
         });
       }
@@ -1537,7 +1538,6 @@ class AwsManager {
       workerType: workerName,
       instances,
       requests,
-      internalTrackedRequests,
     };
   }
 }

--- a/src/provision.js
+++ b/src/provision.js
@@ -139,6 +139,7 @@ class Provisioner {
       let launchInfo = await this.awsManager.workerTypeCanLaunch(toTest);
       if (!launchInfo.canLaunch) {
         disabled.push(toTest.workerType);
+        log.trace({workerType: toTest.workerType}, 'worker type invalid, adding to disabled list');
       }
     }
 
@@ -149,7 +150,9 @@ class Provisioner {
       log.warn({disabled}, 'found worker types which cannot launch, ignoring them');
     }
 
-    return forSpawning.filter(x => _.includes(disabled, x.workerType.workerType));
+    log.trace({forSpawning, disabled}, '__filterBrokenWorkers outcome');
+
+    return forSpawning.filter(x => !_.includes(disabled, x.workerType.workerType));
   }
 
   /**
@@ -231,6 +234,7 @@ class Provisioner {
 
     // Ignore all worker types which we are sure won't be launchable
     forSpawning = await this.__filterBrokenWorkers(workerTypes, forSpawning);
+    log.trace({forSpawning}, 'forSpawning');
 
     // Bucket requests by region
     let byRegion = {};
@@ -245,6 +249,7 @@ class Provisioner {
     }
 
     log.info('starting to submit spot requests');
+    log.debug({byRegion}, 'byRegion');
 
     await Promise.all(_.map(byRegion, async(toSpawn, region) => {
       let rLog = log.child({region});

--- a/src/provision.js
+++ b/src/provision.js
@@ -254,7 +254,9 @@ class Provisioner {
     await Promise.all(_.map(byRegion, async(toSpawn, region) => {
       let rLog = log.child({region});
       rLog.info('starting to submit spot requests in region');
+      let beforeOrderingLength = byRegion[region].length;
       let inRegion = orderThingsInRegion(byRegion[region]);
+      assert(beforeOrderingLength === inRegion.length);
 
       let endLoopAt = new Date();
       endLoopAt.setMinutes(endLoopAt.getMinutes() + 5);

--- a/src/provision.js
+++ b/src/provision.js
@@ -204,7 +204,7 @@ class Provisioner {
         // This does create a bunch of extra logs... darn!
         let state = this.awsManager.stateForStorage(worker.workerType);
         await this.stateContainer.write(worker.workerType, state);
-        wtLog.info('wrote state to azure');
+        wtLog.debug('wrote state to azure');
       } catch (err) {
         wtLog.error(err, 'error writing state to azure');
       }


### PR DESCRIPTION
This includes c772d4d which is a fix to the fallout from today's deployment's issue.

The rest of this patch is to include the internally tracked EC2 spot instance requests in the provisioner state apis.  The new parameter `visibleToEC2Api` will tell us whether the instance is included in the crappy API lag situation we get.