### PR TITLE
Trace logging for incorrect pending capacity

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: node lib/main server | ./node_modules/.bin/bunyan -o short -l info
-provisioner: node lib/main provisioner | ./node_modules/.bin/bunyan -o short -c "this.level > 20 || this.capacityForTypeLog"
+provisioner: node lib/main provisioner | ./node_modules/.bin/bunyan -o short -l info

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: node lib/main server | ./node_modules/.bin/bunyan -o short
-provisioner: node lib/main provisioner | ./node_modules/.bin/bunyan -o short
+web: node lib/main server | ./node_modules/.bin/bunyan -o short -l info
+provisioner: node lib/main provisioner | ./node_modules/.bin/bunyan -o short -c "this.level > 20 || this.capacityForTypeLog"

--- a/src/log.js
+++ b/src/log.js
@@ -1,3 +1,8 @@
 let log = require('taskcluster-lib-log');
 
-module.exports = log('aws-provisioner');
+let env = process.env.NODE_ENV;
+if (!env) {
+  throw new Error('You must have an environment');
+}
+
+module.exports = log('aws-provisioner-' + env.trim());

--- a/src/provision.js
+++ b/src/provision.js
@@ -320,9 +320,22 @@ class Provisioner {
     wtLog.info({pendingTasks}, 'got pending tasks count');
 
     let runningCapacity = this.awsManager.capacityForType(workerType, ['running']);
-    let pendingCapacity = this.awsManager.capacityForType(workerType, ['pending', 'spotReq']);
+    let spotReqCap = this.awsManager.capacityForType(workerType, ['spotReq']);
+    let pendingInstCapacity = this.awsManager.capacityForType(workerType, ['pending']);
+    let pendingCapacity = pendingInstCapacity + spotReqCap;
 
     let change = workerType.determineCapacityChange(runningCapacity, pendingCapacity, pendingTasks);
+
+    log.info({
+      workerType: workerType.workerType,
+      pendingTasks: pendingTasks,
+      runningCapacity: runningCapacity,
+      pendingCapacity: pendingCapacity,
+      spotReqCap: spotReqCap,
+      pendingInstCapacity: pendingInstCapacity,
+      change: change,
+            
+    }, 'changeForType outcome');
 
     // Report on the stats for this iteration
     this.reportProvisioningIteration({

--- a/src/provision.js
+++ b/src/provision.js
@@ -337,6 +337,10 @@ class Provisioner {
             
     }, 'changeForType outcome');
 
+    if (pendingCapacity < 0 && -pendingCapacity > pendingTasks) {
+      log.error('THIS IS A MARKER TO MAKE US LOOK INTO BUG1297811');
+    }
+
     // Report on the stats for this iteration
     this.reportProvisioningIteration({
       provisionerId: this.provisionerId,


### PR DESCRIPTION
Here's some extra logging for this.  It's going to generate a decent amount of extra output, but I don't think that's a huge concern.  I'm also going to add in something to print out when we get into this weird state.