### PR TITLE
make fewer EC2 API Calls

### DIFF
--- a/src/manage.js
+++ b/src/manage.js
@@ -414,7 +414,7 @@ program
       let Table = require('cli-table');
 
       let table = new Table({
-          head: ['WorkerType', 'pendingTasks', 'runningCapacity', 'pendingCapacity', 'requestedCapacity', 'min/max'],
+        head: ['WorkerType', 'pendingTasks', 'runningCapacity', 'pendingCapacity', 'requestedCapacity', 'min/max'],
       });
 
       let summaries = await client.listWorkerTypeSummaries();
@@ -451,7 +451,7 @@ program
       let Table = require('cli-table');
 
       let table = new Table({
-          head: ['WorkerType', 'pendingTasks', 'runningCapacity', 'pendingCapacity', 'requestedCapacity', 'min/max'],
+        head: ['WorkerType', 'pendingTasks', 'runningCapacity', 'pendingCapacity', 'requestedCapacity', 'min/max'],
       });
 
       let summaries = await client.listWorkerTypeSummaries();


### PR DESCRIPTION
@jonasfj i know you've wanted this for a while, but I think it's time.  I don't want to merge the in-process lists because I still think they should be seperate so we don't have to `.filter()` literally every usage.
