### PR TITLE
Don't reqiure NODE_ENV to be set just to run tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pretest": "npm run compile",
     "lint": "eslint src/*.js test-src/*.js",
     "lintfix": "eslint --fix src/*.js test-src/*.js",
-    "test": "npm run lint && npm run compile && mocha test/*_test.js"
+    "test": "npm run lint && npm run compile && NODE_ENV=test mocha test/*_test.js"
   },
   "bin": {
     "manage-provisioner": "./lib/manage.js"


### PR DESCRIPTION
The loader ensures that this value is always set when running the
provisioner directly, but during testing it need not be set.

@anarute 