### PR TITLE
Bug 1335507: sign and encrypt worker types and secrets

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -19,6 +19,12 @@ defaults:
       - 'us-west-2'
       - 'us-east-1'
       - 'eu-central-1'
+
+    # Key for signing in base.Entity (sufficiently random string required)
+    tableSigningKey:          !env TABLE_SIGNING_KEY
+    # Key for data encryption in base.Entity (32 random bytes as base64)
+    tableCryptoKey:           !env TABLE_CRYPTO_KEY
+
   taskcluster:
     authBaseUrl: https://auth.taskcluster.net/v1
     queueBaseUrl: https://queue.taskcluster.net/v1
@@ -137,6 +143,9 @@ test:
     awsInstancePubkey: 'fake-pubkey'
     allowedRegions:
       - 'us-west-2'
+    tableSigningKey:          not-a-secret-so-you-cant-guess-it
+    tableCryptoKey:           AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+
   server:
     publicUrl: http://localhost:60407
     port: 60407

--- a/src/main.js
+++ b/src/main.js
@@ -63,6 +63,8 @@ let load = base.loader({
       let WorkerType = workerType.setup({
         account: cfg.azure.account,
         table: cfg.app.workerTypeTableName,
+        signingKey: cfg.app.tableSigningKey,
+        cryptoKey: cfg.app.tableCryptoKey,
         credentials: cfg.taskcluster.credentials,
         context: {
           keyPrefix: cfg.app.awsKeyPrefix,
@@ -93,6 +95,8 @@ let load = base.loader({
       let Secret = secret.setup({
         account: cfg.azure.account,
         table: cfg.app.secretTableName,
+        signingKey: cfg.app.tableSigningKey,
+        cryptoKey: cfg.app.tableCryptoKey,
         credentials: cfg.taskcluster.credentials,
       });
       return Secret;

--- a/src/secret.js
+++ b/src/secret.js
@@ -15,6 +15,20 @@ let Secret = base.Entity.configure({
   },
 });
 
+// Encrypt the secrets column
+Secret = Secret.configure({
+  version: 2,
+  signEntities: true, // NEW
+  properties: {
+    token: base.Entity.types.String,
+    expiration: base.Entity.types.Date,
+    workerType: base.Entity.types.String,
+    secrets: base.Entity.types.EncryptedJSON,
+    scopes: base.Entity.types.JSON,
+  },
+  migrate: item => item, // no change in the column content, just format
+});
+
 Secret.prototype.modify = function() {
   throw new Error('No modifications of secrets are allowed');
 };

--- a/src/worker-type.js
+++ b/src/worker-type.js
@@ -223,6 +223,34 @@ WorkerType = WorkerType.configure({
   context: ['provisionerId', 'provisionerBaseUrl', 'keyPrefix', 'pubKey'],
 });
 
+// Encrypt the secrets column
+WorkerType = WorkerType.configure({
+  version: 4,
+  signEntities: true, // NEW
+  properties: {
+    // These fields are documented in Version 1 of this Entity
+    workerType: base.Entity.types.String,
+    minCapacity: base.Entity.types.Number,
+    maxCapacity: base.Entity.types.Number,
+    scalingRatio: base.Entity.types.Number,
+    minPrice: base.Entity.types.Number,
+    maxPrice: base.Entity.types.Number,
+    canUseOndemand: base.Entity.types.JSON, // delete this
+    canUseSpot: base.Entity.types.JSON, // delete this
+    instanceTypes: base.Entity.types.JSON,
+    regions: base.Entity.types.JSON,
+    lastModified: base.Entity.types.Date,
+    userData: base.Entity.types.JSON,
+    launchSpec: base.Entity.types.JSON,
+    secrets: base.Entity.types.EncryptedJSON,
+    scopes: base.Entity.types.JSON,
+    description: base.Entity.types.String,
+    owner: base.Entity.types.String,
+  },
+  migrate: item => item, // no change in the column content, just format
+  context: ['provisionerId', 'provisionerBaseUrl', 'keyPrefix', 'pubKey'],
+});
+
 /**
  * Create a workerType in the table.  The properties
  * should not have a workerType key since that will be


### PR DESCRIPTION
With this change, someone intercepting a copy of our table backups will
not get any secrets.  A restore will also verify the signature on the
rows, avoiding the risk of modification.  Otherwise, there is no impact.

Deployment will require setting TABLE_SIGNING_KEY and TABLE_CRYPTO_KEY.