### PR TITLE
bug 1318648 - support instance instantiation in us-east-2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -17,6 +17,7 @@ defaults:
       - 'us-west-1'
       - 'us-west-2'
       - 'us-east-1'
+      - 'us-east-2'
       - 'eu-central-1'
 
     # Key for signing in base.Entity (sufficiently random string required)
@@ -128,6 +129,7 @@ development:
       - 'us-west-1'
       - 'us-west-2'
       - 'us-east-1'
+      - 'us-east-2'
       - 'eu-central-1'
 
 test:

--- a/schemas/create-worker-type-request.yml
+++ b/schemas/create-worker-type-request.yml
@@ -144,6 +144,7 @@ properties:
           enum:
             - us-west-2
             - us-east-1
+            - us-east-2
             - us-west-1
             - eu-central-1
         launchSpec:


### PR DESCRIPTION
in anticipation of increased load for g2.2xlarge (gecko-t-win7-32-gpu, gecko-t-win10-64-gpu worker types) enable instance instantiation in us-east-2 to mitigate cost and availability issues