### PR TITLE
Move to integrations tier

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -134,7 +134,7 @@ let load = loader({
       });
       return docs.documenter({
         credentials: cfg.taskcluster.credentials,
-        tier: 'core',
+        tier: 'integrations',
         schemas: validator.schemas,
         project: 'aws-provisioner',
         references: [


### PR DESCRIPTION
Just moving this to where it was placed in docs itself after our move.

@jhford just a heads up on this although I expect it to cause you no issues. Maybe land it if it is approved since I don't know if aws-provisioner auto-deploys or something?