### PR TITLE
Stop using Influx

### DIFF
--- a/src/influx-series.js
+++ b/src/influx-series.js
@@ -1,4 +1,3 @@
-let stats = require('taskcluster-lib-stats');
 
 // This is a time series to measure how long it takes for instances to show up
 // in the AWS api responses

--- a/src/main.js
+++ b/src/main.js
@@ -275,16 +275,7 @@ let load = loader({
   influx: {
     requires: ['cfg'],
     setup: ({cfg}) => {
-      if (cfg.influx.connectionString) {
-        return new stats.Influx({
-          connectionString: cfg.influx.connectionString,
-          maxDelay: cfg.influx.maxDelay,
-          maxPendingPoints: cfg.influx.maxPendingPoints,
-        });
-      } else {
-        console.log('No influx.connectionString configured; not using influx');
-        return new stats.NullDrain();
-      }
+      return new stats.NullDrain();
     },
   },
 


### PR DESCRIPTION
Rather than changing the code too much right now, let's just use a NullDrain for lib-stats.  Because of how the metrics are reported, actually removing the calls might be a little more difficult