### PR TITLE
Move delay intervals to env variables

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,7 +5,7 @@ defaults:
     publishMetaData: !env:bool PUBLISH_METADATA
     iterationInterval: !env ITERATION_INTERVAL
     describeInstanceDelay: !env DESCRIBE_INSTANCE_DELAY
-    describeSpotInstanceDelay: !env DESCRIBE_SPOT_INSTANCE_DELAY
+    describeSpotRequestDelay: !env DESCRIBE_SPOT_REQUEST_DELAY
     maxInstanceLife: '- 96 hours'
     id: !env PROVISIONER_ID
     workerTypeTableName: DevWorkerTypes2
@@ -87,7 +87,7 @@ production:
     awsKeyPrefix: "aws-provisioner-v1-managed:"
     iterationInterval: !env ITERATION_INTERVAL
     describeInstanceDelay: !env DESCRIBE_INSTANCE_DELAY
-    describeSpotInstanceDelay: !env DESCRIBE_SPOT_INSTANCE_DELAY
+    describeSpotRequestDelay: !env DESCRIBE_SPOT_REQUEST_DELAY
     allowedRegions: !env:list ALLOWED_REGIONS
   monitor:
     project: 'aws-provisioner'
@@ -112,7 +112,7 @@ staging:
     awsKeyPrefix: "staging-aws-managed:"
     iterationInterval: 300
     describeInstanceDelay: 5000
-    describeSpotInstanceDelay: 5000
+    describeSpotRequestDelay: 5000
     allowedRegions: !env:list ALLOWED_REGIONS
   monitor:
     project: 'staging-aws'

--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,9 @@
 defaults:
   app:
     publishMetaData: !env:bool PUBLISH_METADATA
-    iterationInterval: 120
+    iterationInterval: !env ITERATION_INTERVAL
+    describeInstanceDelay: !env DESCRIBE_INSTANCE_DELAY
+    describeSpotInstanceDelay: !env DESCRIBE_SPOT_INSTANCE_DELAY
     maxInstanceLife: '- 96 hours'
     id: !env PROVISIONER_ID
     workerTypeTableName: DevWorkerTypes2
@@ -83,7 +85,9 @@ production:
     publishMetaData: true
     statsComponent: aws-provisioner-v1
     awsKeyPrefix: "aws-provisioner-v1-managed:"
-    iterationInterval: 120
+    iterationInterval: !env ITERATION_INTERVAL
+    describeInstanceDelay: !env DESCRIBE_INSTANCE_DELAY
+    describeSpotInstanceDelay: !env DESCRIBE_SPOT_INSTANCE_DELAY
     allowedRegions: !env:list ALLOWED_REGIONS
   monitor:
     project: 'aws-provisioner'
@@ -107,6 +111,8 @@ staging:
     statsComponent: staging-aws
     awsKeyPrefix: "staging-aws-managed:"
     iterationInterval: 300
+    describeInstanceDelay: 5000
+    describeSpotInstanceDelay: 5000
     allowedRegions: !env:list ALLOWED_REGIONS
   monitor:
     project: 'staging-aws'

--- a/src/aws-manager.js
+++ b/src/aws-manager.js
@@ -186,7 +186,7 @@ async function runAWSRequest(service, method, body) {
  *      submit data points to a statsum instance
  */
 class AwsManager {
-  constructor(ec2, provisionerId, keyPrefix, pubKey, maxInstanceLife, influx, monitor, ec2manager) {
+  constructor(ec2, provisionerId, keyPrefix, pubKey, maxInstanceLife, influx, monitor, ec2manager, describeInstanceDelay, describeSpotRequestDelay) {
     assert(ec2);
     assert(provisionerId);
     assert(keyPrefix);
@@ -195,7 +195,7 @@ class AwsManager {
     assert(influx);
     assert(monitor);
     assert(describeInstanceDelay);
-    assert(describeSpotInstanceDelay);
+    assert(describeSpotRequestDelay);
 
     this.ec2 = ec2;
     this.provisionerId = provisionerId;
@@ -351,7 +351,7 @@ class AwsManager {
             },
           ],
         });
-        await delayer(describeSpotInstanceDelay)();
+        await delayer(describeSpotRequestDelay)();
 
         rLog.info({state}, 'fetched requests in state for region');
 

--- a/src/aws-manager.js
+++ b/src/aws-manager.js
@@ -194,6 +194,8 @@ class AwsManager {
     assert(maxInstanceLife);
     assert(influx);
     assert(monitor);
+    assert(describeInstanceDelay);
+    assert(describeSpotInstanceDelay);
 
     this.ec2 = ec2;
     this.provisionerId = provisionerId;
@@ -317,7 +319,7 @@ class AwsManager {
             },
           ],
         });
-        await delayer(1000)();
+        await delayer(describeInstanceDelay)();
         rLog.info({state}, 'fetched instances in state for region');
         for (let reservation of instances.Reservations) {
           for (let instance of reservation.Instances) {
@@ -349,7 +351,7 @@ class AwsManager {
             },
           ],
         });
-        await delayer(1000)();
+        await delayer(describeSpotInstanceDelay)();
 
         rLog.info({state}, 'fetched requests in state for region');
 

--- a/src/main.js
+++ b/src/main.js
@@ -293,7 +293,7 @@ let load = loader({
         monitor.prefix('awsManager'),
         ec2manager,
         cfg.app.describeInstanceDelay,
-        cfg.app.describeSpotInstanceDelay)
+        cfg.app.describeSpotRequestDelay)
       );
     },
   },

--- a/src/main.js
+++ b/src/main.js
@@ -292,6 +292,8 @@ let load = loader({
         influx,
         monitor.prefix('awsManager'),
         ec2manager,
+        cfg.app.describeInstanceDelay,
+        cfg.app.describeSpotInstanceDelay)
       );
     },
   },


### PR DESCRIPTION
At times we need to adjust the delays between iterations and describe (spot) instance requests.  instead of submitting it via code commits, let's have the dials in the app settings.

Note this will require setting the following app settings:
ITERATION_INTERVAL
DESCRIBE_INSTANCE_DELAY
DESCRIBE_SPOT_INSTANCE_DELAY