### PR TITLE
stop sending the scopes list from the worker type definition

### DIFF
--- a/lib/api-v1.js
+++ b/lib/api-v1.js
@@ -496,8 +496,7 @@ api.declare({
   stability:  API.stability.stable,
   description: [
     'Insert a secret into the secret storage.  The supplied secrets will',
-    'be provided verbatime via `getSecret`, while the supplied scopes will',
-    'be converted into credentials by `getSecret`.',
+    'be provided verbatime via `getSecret`.',
     '',
     'This method is not ordinarily used in production; instead, the provisioner',
     'creates a new secret directly for each spot bid.',
@@ -515,7 +514,7 @@ api.declare({
       workerType: input.workerType,
       availabilityZones: [],
       secrets: input.secrets,
-      scopes: input.scopes,
+      scopes: [],
       expiration: new Date(input.expiration),
     });
   } catch (err) {
@@ -563,7 +562,7 @@ api.declare({
   description: [
     'Retrieve a secret from storage.  The result contains any passwords or',
     'other restricted information verbatim as well as a temporary credential',
-    'based on the scopes specified when the secret was created.',
+    'based on the provisioner id and worker type',
     '',
     'It is important that this secret is deleted by the consumer (`removeSecret`),',
     'or else the secrets will be visible to any process which can access the',
@@ -579,7 +578,7 @@ api.declare({
 
     return res.reply({
       data: secret.secrets,
-      scopes: secret.scopes,
+      scopes: [],
       credentials: taskcluster.createTemporaryCredentials({
         scopes: [
           `assume:worker-type:${this.provisionerId}/${secret.workerType}`,


### PR DESCRIPTION
While this list was not involved in any of the credential generation, we should still send the correct list of scopes back.