### PR TITLE
Worker Types should be created with no security groups

### DIFF
--- a/src/aws-manager.js
+++ b/src/aws-manager.js
@@ -369,6 +369,11 @@ class AwsManager {
       let launchSpecsRegion = worker.instanceTypes.map(t => launchSpecs[r.region][t.instanceType].launchSpec);
       let allSGForRegion = _.uniq(_.flatten(launchSpecsRegion.map(spec => spec.SecurityGroups)));
 
+      if (allSGForRegion.length === 0) {
+        log.info({workerType: worker.workerType}, 'no security groups configured');
+        return;
+      }
+
       let hasAllRequiredSG = await sgExists(this.ec2[r.region], allSGForRegion);
       log.debug({allSGForRegion, hasAllRequiredSG}, 'security group check outcome');
       if (!hasAllRequiredSG) {

--- a/test-src/manageworkertype_test.js
+++ b/test-src/manageworkertype_test.js
@@ -85,6 +85,31 @@ describe('provisioner worker type api', () => {
     }
   });
 
+  it('should create worker with no security group specified', async () => {
+    let missingSecurityGroup = makeWorkerType({
+      launchSpec: {},
+    });
+    try {
+      await client.createWorkerType(id, missingSecurityGroup);
+      return Promise.reject();
+    } catch (err) {
+      return Promise.resolve();
+    }
+  });
+
+  it('should create worker with empty security group list specified', async () => {
+    let missingSecurityGroup = makeWorkerType({
+      launchSpec: {
+        SecurityGroups: [],
+      },
+    });
+    try {
+      await client.createWorkerType(id, missingSecurityGroup);
+      return Promise.reject();
+    } catch (err) {
+      return Promise.resolve();
+    }
+  });
   it('should be able to create a worker (idempotent)', async () => {
     debug('### Create workerType');
     await client.createWorkerType(id, workerTypeDefinition);


### PR DESCRIPTION
I'm taking a guess that this is the right thing.  I hope it is.

Worker types should not need to specify a list of security groups in the
case where we are denying all inbound traffic.