### PR TITLE
Fix ALLOWED_REGIONS

### DIFF
--- a/src/aws-manager.js
+++ b/src/aws-manager.js
@@ -338,6 +338,10 @@ class AwsManager {
     }
 
     await Promise.all(worker.regions.map(async r => {
+      if (!this.ec2[r.region]) {
+        // this region is not in cfg.app.allowedRegions
+        return;
+      }
       await Promise.all(worker.instanceTypes.map(async t => {
         let launchSpec = launchSpecs[r.region][t.instanceType].launchSpec;
 


### PR DESCRIPTION
Without this fix, amiExisets is called without an EC2 client object for
regions defined in a workerType but not in ALLOWED_REGIONS (and thus not
in `this.ec2`)

Later provisioning *should* work, as it limits spot bids to
`_.keys(this.awsManager.ec2)`