### PR TITLE
Bug 1388436 - allow specification of per-AZ launchSpec

### DIFF
--- a/schemas/create-worker-type-request.yml
+++ b/schemas/create-worker-type-request.yml
@@ -180,6 +180,34 @@ properties:
         - secrets
         - userData
         - scopes
+  availabilityZones:
+    type: array
+    items:
+      type: object
+      description: Availability zone configuration
+      properties:
+        availabilityZone:
+          type: string
+          description: |
+            The AWS availability zone being configured.  Example: eu-central-1b
+        launchSpec:
+          type: object
+          description: |
+            LaunchSpecification entries unique to this AZ
+        secrets:
+          type: object
+          description: |
+            Static Secrets unique to this AZ
+          default: {}
+        userData:
+          type: object
+          description: |
+            UserData entries unique to this AZ
+          default: {}
+      additionalProperties: false
+      required:
+        - availabilityZone
+        - launchSpec
 additionalProperties: false
 required:
   - launchSpec

--- a/schemas/get-worker-type-response.yml
+++ b/schemas/get-worker-type-response.yml
@@ -185,6 +185,34 @@ properties:
         - secrets
         - userData
         - scopes
+  availabilityZones:
+    type: array
+    items:
+      type: object
+      description: Availability zone configuration
+      properties:
+        availabilityZone:
+          type: string
+          description: |
+            The AWS availability zone being configured.  Example: eu-central-1b
+        launchSpec:
+          type: object
+          description: |
+            LaunchSpecification entries unique to this AZ
+        secrets:
+          type: object
+          description: |
+            Static Secrets unique to this AZ
+          default: {}
+        userData:
+          type: object
+          description: |
+            UserData entries unique to this AZ
+          default: {}
+      additionalProperties: false
+      required:
+        - availabilityZone
+        - launchSpec
 additionalProperties: false
 required:
   - workerType


### PR DESCRIPTION
This adds a new, non-required sibling to `regions` in the worker type schema, and then mixes this data into the launch spec used to create the instance.

It's untested - hopefully we can test this in staging.