### PR TITLE
Bug 1388436 - support subnet IDs

### DIFF
--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -190,12 +190,11 @@ api.declare({
   let launchInfo = await this.awsManager.workerTypeCanLaunch(workerForValidation, this.WorkerType);
   if (!launchInfo.canLaunch) {
     log.debug({launchInfo}, 'cannot launch this worker type submission');
-    return res.status(400).json({
-      message: 'Invalid workerType: ' + JSON.stringify(launchInfo.reasons.map(e => e.stack || e)),
-      error: {
-        reasons: launchInfo.reasons,
-      },
-    });
+    let reasons = launchInfo.reasons.map(e => e.toString());
+    return res.reportError(
+      'InputError',
+      'Invalid workerType: ' + reasons.join('; '),
+      {reasons});
   }
 
   // Create workerType
@@ -298,12 +297,11 @@ api.declare({
   let launchInfo = await this.awsManager.workerTypeCanLaunch(workerForValidation, this.WorkerType);
   if (!launchInfo.canLaunch) {
     log.debug({launchInfo}, 'cannot launch this worker type submission');
-    return res.status(400).json({
-      message: 'Invalid workerType: ' + JSON.stringify(launchInfo.reasons.map(e => e.stack || e)),
-      error: {
-        reasons: launchInfo.reasons,
-      },
-    });
+    let reasons = launchInfo.reasons.map(e => e.toString());
+    return res.reportError(
+      'InputError',
+      'Invalid workerType: ' + reasons.join('; '),
+      {reasons});
   }
 
   let wType = await this.WorkerType.load({workerType: workerType});

--- a/src/aws-manager.js
+++ b/src/aws-manager.js
@@ -333,7 +333,11 @@ class AwsManager {
       }
     } catch (err) {
       returnValue.canLaunch = false;
-      returnValue.reasons.push(err);
+      if (err.code === 'InvalidLaunchSpecifications') {
+        returnValue.reasons = returnValue.reasons.concat(err.reasons);
+      } else {
+        returnValue.reasons.push(err);
+      }
       return returnValue;
     }
 

--- a/src/aws-manager.js
+++ b/src/aws-manager.js
@@ -374,20 +374,23 @@ class AwsManager {
         }
       }));
 
+      // check security group names
       let launchSpecsRegion = worker.instanceTypes.map(t => launchSpecs[r.region][t.instanceType].launchSpec);
-      let allSGForRegion = _.uniq(_.flatten(launchSpecsRegion.map(spec => spec.SecurityGroups)));
+      let allSGForRegion = _.uniq(_.flatten(launchSpecsRegion.map(spec => spec.SecurityGroups).filter(g => g)));
 
-      let hasAllRequiredSG = await sgExists(this.ec2[r.region], allSGForRegion);
-      log.debug({allSGForRegion, hasAllRequiredSG}, 'security group check outcome');
-      if (!hasAllRequiredSG) {
-        returnValue.canLaunch = false;
-        let err = new Error('Missing one or more security groups');
-        err.requested = allSGForRegion;
-        returnValue.reasons.push(err);
-        log.warn({
-          region: r.region,
-          neededGroups: allSGForRegion,
-        }, 'missing security groups');
+      if (allSGForRegion.length !== 0) {
+        let hasAllRequiredSG = await sgExists(this.ec2[r.region], allSGForRegion);
+        log.debug({allSGForRegion, hasAllRequiredSG}, 'security group check outcome');
+        if (!hasAllRequiredSG) {
+          returnValue.canLaunch = false;
+          let err = new Error('Missing one or more security groups');
+          err.requested = allSGForRegion;
+          returnValue.reasons.push(err);
+          log.warn({
+            region: r.region,
+            neededGroups: allSGForRegion,
+          }, 'missing security groups');
+        }
       }
     }));
 

--- a/src/worker-type.js
+++ b/src/worker-type.js
@@ -625,6 +625,11 @@ WorkerType.createLaunchSpec = function(bid, worker, keyPrefix, provisionerId, pr
     assert(_.includes(allowedKeys, key), 'Your launch spec has invalid key ' + key);
   }
 
+  // Can't use SecurityGroups with a SubnetId (non-default VPC)
+  if (config.launchSpec.SubnetId && config.launchSpec.SecurityGroups) {
+    throw new Error('cannot use SecurityGroup with SubnetId (use SecurityGroupIds');
+  }
+
   // These are keys which we do not allow in the generated launch spec
   let disallowedKeys = [
   ];
@@ -667,7 +672,7 @@ WorkerType.testLaunchSpecs = function(worker, keyPrefix, provisionerId, provisio
     for (let t of worker.instanceTypes) {
       let type = t.instanceType;
       let zones = worker.availabilityZones
-        .map(z => z.name)
+        .map(z => z.availabilityZone)
         .filter(n => n.startsWith(region));
       // if no zones are configured, fall back to the 'a' region
       if (zones.length === 0) {

--- a/src/worker-type.js
+++ b/src/worker-type.js
@@ -480,7 +480,7 @@ WorkerType.createLaunchSpec = function(bid, worker, keyPrefix, provisionerId, pr
       selectedAZ.availabilityZone = az.availabilityZone;
     }
   }
-  assert(availabilityZones.length == 0 || foundAz, bid.zone + ' not found in worker.availabilityZones');
+  assert(availabilityZones.length == 0 || foundAZ, bid.zone + ' not found in worker.availabilityZones');
 
   // Find the instanceType overwrites object, assert if type is not found
   let selectedInstanceType = {};

--- a/src/worker-type.js
+++ b/src/worker-type.js
@@ -687,7 +687,7 @@ WorkerType.testLaunchSpecs = function(worker, keyPrefix, provisionerId, provisio
             workerName);
         launchSpecs[region][type] = x;
       } catch (e) {
-        errors.push(e);
+        errors.push(e.toString());
       }
     }
   }

--- a/src/worker-type.js
+++ b/src/worker-type.js
@@ -552,17 +552,13 @@ WorkerType.createLaunchSpec = function(bid, worker, keyPrefix, provisionerId, pr
   config.launchSpec.KeyName = keyPairs.createKeyPairName(keyPrefix, pubKey, workerName);
   config.launchSpec.InstanceType = bid.type;
 
-  // Only set the placement if a SubnetId wasn't specified.  Placement only
-  // works for EC2-Classic, so for non-classic VPCs the SubnetId must be
-  // given explicitly
-  if (!config.launchSpec.SubnetId) {
-    if (!config.launchSpec.Placement) {
-      config.launchSpec.Placement = {
-        AvailabilityZone: bid.zone,
-      };
-    } else {
-      config.launchSpec.Placement.AvailabilityZone = bid.zone;
-    }
+  // Set Placement.AvailabilityZone.
+  if (!config.launchSpec.Placement) {
+    config.launchSpec.Placement = {
+      AvailabilityZone: bid.zone,
+    };
+  } else {
+    config.launchSpec.Placement.AvailabilityZone = bid.zone;
   }
 
   // Here are the minimum number of things which must be stored in UserData.

--- a/src/worker-type.js
+++ b/src/worker-type.js
@@ -606,6 +606,7 @@ WorkerType.createLaunchSpec = function(bid, worker, keyPrefix, provisionerId, pr
   // These are the additional keys which *might* be specified
   let allowedKeys = mandatoryKeys.concat([
     'SecurityGroups',
+    'SecurityGroupIds',
     'AddressingType',
     'BlockDeviceMappings',
     'EbsOptimized',

--- a/src/worker-type.js
+++ b/src/worker-type.js
@@ -669,25 +669,34 @@ WorkerType.testLaunchSpecs = function(worker, keyPrefix, provisionerId, provisio
     launchSpecs[region] = {};
     for (let t of worker.instanceTypes) {
       let type = t.instanceType;
-      try {
-        let bid = {
-          price: 1,
-          truePrice: 1,
-          region: region,
-          type: type,
-          zone: 'fakezone1',
-        };
-        let x = WorkerType.createLaunchSpec(
-            bid,
-            worker,
-            keyPrefix,
-            provisionerId,
-            provisionerBaseUrl,
-            pubKey,
-            workerName);
-        launchSpecs[region][type] = x;
-      } catch (e) {
-        errors.push(e.toString());
+      let zones = worker.availabilityZones
+        .map(z => z.name)
+        .filter(n => n.startsWith(region));
+      // if no zones are configured, fall back to the 'a' region
+      if (zones.length === 0) {
+        zones = [region + 'a'];
+      }
+      for (let zone of zones) {
+        try {
+          let bid = {
+            price: 1,
+            truePrice: 1,
+            region: region,
+            type: type,
+            zone,
+          };
+          let x = WorkerType.createLaunchSpec(
+              bid,
+              worker,
+              keyPrefix,
+              provisionerId,
+              provisionerBaseUrl,
+              pubKey,
+              workerName);
+          launchSpecs[region][type] = x;
+        } catch (e) {
+          errors.push(e.toString());
+        }
       }
     }
   }


### PR DESCRIPTION
This seems sufficient in my testing.  After our conversation today about requiring users to enter security group IDs instead of names, it all fell into place.  EC2 requires those group IDs in a different LaunchSpec field anyway, so there's no need to disambiguate old (default VPC) vs. new (explicit subnet / vpc) worker types.  No changes are required for EC2-manager, as it is just accepting the LaunchSpec as given.

This seems too simple, but it seems to work and I can't find anything missing.