### PR TITLE
Use 'terminate' instead of 'kill'

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -402,7 +402,7 @@ let load = loader({
               description: cfg.app.description,
               actions: [{
                 name: 'kill',
-                title: 'Kill',
+                title: 'Terminate',
                 context: 'worker',
                 url: `${cfg.ec2manager.baseUrl}/region/<workerGroup>/instance/<workerId>`,
                 method: 'DELETE',


### PR DESCRIPTION
There's no need to use a violent term like "kill".  Terminate may remind
some of a series of action movies, but it's at least a little more
clinical, and anyway corresponds to the EC2 terminology.

This leaves the `name` unchanged, as it is still performing the same
action.  It just changes the displayed text.