### PR TITLE
More robust pricing

### DIFF
--- a/src/provision.js
+++ b/src/provision.js
@@ -142,7 +142,15 @@ class Provisioner {
     let workerTypes;
     workerTypes = await this.WorkerType.loadAll();
     log.info('loaded worker types');
-    await this.awsManager.update();
+    let instanceTypes = [];
+    for (let w of workerTypes) {
+      for (let t of w.instanceTypes) {
+        if (!instanceTypes.includes(t.instanceType)) {
+          instanceTypes.push(t.instanceType);
+        }
+      }
+    }
+    await this.awsManager.update(instanceTypes);
     log.info('updated aws state');
 
     let workerNames = workerTypes.map(w => w.workerType);

--- a/src/worker-type.js
+++ b/src/worker-type.js
@@ -815,12 +815,6 @@ WorkerType.prototype.determineSpotBids = function(managedRegions, pricing, chang
 
   /* eslint-disable no-loop-func */
   while (change > 0) {
-    let cheapestType;
-    let cheapestRegion;
-    let cheapestZone;
-    let cheapestPrice;
-    let cheapestBid;
-
     // Utility Factors, by instance type
     let uf = {};
 
@@ -906,12 +900,7 @@ WorkerType.prototype.determineSpotBids = function(managedRegions, pricing, chang
     }
 
     // pick a random zone to bid into
-    let cheapest = _.sample(bidOptions);
-    cheapestPrice = cheapest.cheapestPrice;
-    cheapestRegion = cheapest.cheapestRegion;
-    cheapestType = cheapest.cheapestType;
-    cheapestZone = cheapest.cheapestZone;
-    cheapestBid = cheapest.cheapestBid;
+    let {cheapestPrice, cheapestRegion, cheapestType, cheapestZone, cheapestBid} = _.sample(bidOptions);
 
     if (cheapestPrice < this.minPrice) {
       let oldCheapestBid = cheapestBid;

--- a/src/worker-type.js
+++ b/src/worker-type.js
@@ -815,6 +815,12 @@ WorkerType.prototype.determineSpotBids = function(managedRegions, pricing, chang
 
   /* eslint-disable no-loop-func */
   while (change > 0) {
+    let cheapestType;
+    let cheapestRegion;
+    let cheapestZone;
+    let cheapestPrice;
+    let cheapestBid;
+
     // Utility Factors, by instance type
     let uf = {};
 
@@ -843,7 +849,6 @@ WorkerType.prototype.determineSpotBids = function(managedRegions, pricing, chang
 
     let priceTrace = [];
 
-    let bidOptions = [];
     for (let region of regions) {
       for (let type of types) {
         let zones = [];
@@ -872,13 +877,51 @@ WorkerType.prototype.determineSpotBids = function(managedRegions, pricing, chang
             let potentialPrice = potentialBid / uf[type];
             assert(typeof potentialBid === 'number');
             assert(typeof potentialPrice === 'number');
-            bidOptions.push({
-              cheapestPrice: potentialPrice,
-              cheapestRegion: region,
-              cheapestType: type,
-              cheapestZone: zone,
-              cheapestBid: Math.ceil(potentialBid * 2 * 1000000) / 1000000,
-            });
+            if (!cheapestPrice) {
+              // If we don't already have a cheapest price, that means we
+              // should just take the first one we see
+              priceTrace.push({
+                outcome: 'first-possibility',
+                action: 'selected',
+                region,
+                zone,
+                type,
+                price: potentialPrice,
+                bid: potentialBid,
+              });
+              cheapestPrice = potentialPrice;
+              cheapestRegion = region;
+              cheapestType = type;
+              cheapestZone = zone;
+              cheapestBid = Math.ceil(potentialBid * 2 * 1000000) / 1000000;
+            } else if (potentialPrice < cheapestPrice) {
+              // If we find that we have a cheaper option, let's switch to it
+              priceTrace.push({
+                outcome: 'cheaper',
+                action: 'selected',
+                region,
+                zone,
+                type,
+                price: potentialPrice,
+                bid: potentialBid,
+              });
+              cheapestPrice = potentialPrice;
+              cheapestRegion = region;
+              cheapestType = type;
+              cheapestZone = zone;
+              cheapestBid = Math.ceil(potentialBid * 2 * 1000000) / 1000000;
+            } else {
+              // If we're cheaper here, we'll ignore this option.
+              priceTrace.push({
+                outcome: 'more-expensive',
+                action: 'ignored',
+                region,
+                zone,
+                type,
+                price: potentialPrice,
+                bid: potentialBid,
+              });
+            }
           } catch (err) {
             console.log(err);
             console.dir(pricingData);
@@ -891,16 +934,13 @@ WorkerType.prototype.determineSpotBids = function(managedRegions, pricing, chang
       }
     }
 
-    if (!bidOptions.length) {
+    if (!cheapestBid) {
       log.error({
         workerType: this.workerType,
         priceTrace: priceTrace,
       }, 'could not create any bid');
       throw new Error('Could not create any bid for ' + this.workerType);
     }
-
-    // pick a random zone to bid into
-    let {cheapestPrice, cheapestRegion, cheapestType, cheapestZone, cheapeastBid} = _.sample(bidOptions);
 
     if (cheapestPrice < this.minPrice) {
       let oldCheapestBid = cheapestBid;

--- a/src/worker-type.js
+++ b/src/worker-type.js
@@ -900,7 +900,7 @@ WorkerType.prototype.determineSpotBids = function(managedRegions, pricing, chang
     }
 
     // pick a random zone to bid into
-    let {cheapestPrice, cheapestRegion, cheapestType, cheapestZone, cheapestBid} = _.sample(bidOptions);
+    let {cheapestPrice, cheapestRegion, cheapestType, cheapestZone, cheapeastBid} = _.sample(bidOptions);
 
     if (cheapestPrice < this.minPrice) {
       let oldCheapestBid = cheapestBid;


### PR DESCRIPTION
I think the issues we were seeing were related more to not having see a price change recently than prices being too low or not having available az.  I think this should address that issue by loading significantly more data (4h instead of 30m) as well as reading all values of the request instead of just the first page.  Both of those things worked well in highly volatile spot price markets, but not in the new world with smoother pricing.

As well, this also requests prices only for those instance types which the provisioner knows it might need to work with.  This is to lower load on the EC2 api and hopefully result in fewer API errors