### PR TITLE
Bug 1428068: Update prices through ec2-manager

### DIFF
--- a/test-src/mock-ec2manager.js
+++ b/test-src/mock-ec2manager.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+module.exports = () => {
+  const prices = fs.readFileSync(path.resolve(
+    __dirname,
+    '../test-src/prices.json')
+  ).toString();
+  const app = express();
+  app.get('/v1/prices', (req, res) => res.send(prices));
+  return app.listen(5555);
+};

--- a/test-src/mock-workers.js
+++ b/test-src/mock-workers.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var wt = require('../lib/worker-type');
 
 var baseWorkerType = {
   launchSpec: {
@@ -52,6 +53,11 @@ var baseWorkerType = {
   ],
   availabilityZones: [],
 };
+
+// Copy WorkerType methods to our mock object
+_.forEach(wt.prototype, (fn, fname) => {
+  baseWorkerType[fname] = fn;
+});
 
 function makeRegion(overwrites) {
   return _.defaults(overwrites || {}, {

--- a/test-src/price_update_test.js
+++ b/test-src/price_update_test.js
@@ -1,0 +1,119 @@
+const fakeEC2Manager = require('./mock-ec2manager');
+const AwsManager = require('../lib/aws-manager');
+const taskcluster = require('taskcluster-client');
+const mock = require('./mock-workers');
+const request = require('request-promise');
+const assert = require('assert');
+
+// for convenience
+const makeRegion = mock.makeRegion;
+const makeInstanceType = mock.makeInstanceType;
+const makeWorkerType = mock.makeWorkerType;
+
+function describeAvailabilityZones() {
+  return {
+    promise: async () => {
+      return {
+        AvailabilityZones: [
+          {
+            ZoneName: 'us-east-1a',
+            ZoneState: 'available',
+            RegionName: 'us-east-1',
+          },
+          {
+            ZoneName: 'us-east-1b',
+            ZoneState: 'available',
+            RegionName: 'us-east-1',
+          },
+          {
+            ZoneName: 'us-east-1c',
+            ZoneState: 'available',
+            RegionName: 'us-east-1',
+          },
+          {
+            ZoneName: 'us-east-1b',
+            ZoneState: 'available',
+            RegionName: 'us-east-1',
+          },
+        ],
+      };
+    },
+  };
+}
+
+async function createEC2ManagerClient() {
+  const ec2ManagerBaseUrl = 'https://ec2-manager.herokuapp.com/v1';
+
+  let reference = await request.get(ec2ManagerBaseUrl + '/internal/api-reference');
+  reference = JSON.parse(reference);
+
+  const clientClass = taskcluster.createClient(reference);
+
+  const client = new clientClass({
+    agent: require('http').globalAgent,
+    baseUrl: ec2ManagerBaseUrl,
+    credentials: {
+      clientId: process.env.TASKCLUSTER_CLIENT_ID,
+      accessToken: process.env.TASKCLUSTER_ACCESS_TOKEN,
+    },
+    timeout: 2 * 1000,
+  });
+
+  return client;
+}
+
+describe('ec2manager', () => {
+  let server;
+
+  before(() => {
+    // run our fake ec2-manager server
+    server = fakeEC2Manager();
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  it('price update', async () => {
+    const workerType = makeWorkerType({
+      lastModified: new Date(),
+      regions: [makeRegion({region: 'us-east-1'})],
+      instanceTypes: [makeInstanceType()],
+    });
+
+    const manager = new AwsManager(
+      {
+        'us-east-1': {
+          describeAvailabilityZones,
+          config: {
+            region: 'us-east-1',
+          },
+          serviceIdentifier: 'aws-provisioner-test',
+        },
+      },
+      'aws-provisioner-v1',
+      {},
+      await createEC2ManagerClient(),
+      'test',
+      'mypubkey',
+    );
+
+    await manager.update();
+    const bids = workerType.determineSpotBids(
+      ['us-east-1'],
+      manager.__pricing,
+      1,
+    );
+
+    assert.deepEqual(
+      bids[0],
+      {
+        price: 0.04,
+        truePrice: 0.02,
+        region: 'us-east-1',
+        type: 't1.micro',
+        zone: 'us-east-1e',
+      },
+    );
+  });
+});

--- a/test-src/prices.json
+++ b/test-src/prices.json
@@ -1,0 +1,10684 @@
+[
+  {
+    "zone": "us-west-2c",
+    "instanceType": "t1.micro",
+    "price": 0.002,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "t1.micro",
+    "price": 0.002,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "t1.micro",
+    "price": 0.002,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "t1.micro",
+    "price": 0.002,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "t1.micro",
+    "price": 0.002,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "t1.micro",
+    "price": 0.002,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "t1.micro",
+    "price": 0.002,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "t1.micro",
+    "price": 0.002,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "t1.micro",
+    "price": 0.002,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m1.large",
+    "price": 0.0022,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m1.large",
+    "price": 0.0022,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m1.large",
+    "price": 0.0022,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "t2.micro",
+    "price": 0.0025,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "t1.micro",
+    "price": 0.0025,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "t1.micro",
+    "price": 0.0025,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "t2.micro",
+    "price": 0.0025,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "t2.micro",
+    "price": 0.0026,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "t2.micro",
+    "price": 0.003,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "t2.micro",
+    "price": 0.003,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "t2.micro",
+    "price": 0.003,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "t2.micro",
+    "price": 0.003,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "t2.micro",
+    "price": 0.0031,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "t2.micro",
+    "price": 0.0031,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "t2.micro",
+    "price": 0.0033,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "t2.micro",
+    "price": 0.0033,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "t2.micro",
+    "price": 0.0033,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "t2.micro",
+    "price": 0.0034,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "t2.micro",
+    "price": 0.0034,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "t2.micro",
+    "price": 0.0034,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "t2.micro",
+    "price": 0.0035,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "t2.micro",
+    "price": 0.0035,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "t2.micro",
+    "price": 0.0035,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "t2.micro",
+    "price": 0.0035,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "t2.micro",
+    "price": 0.0035,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m1.small",
+    "price": 0.0044,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m1.small",
+    "price": 0.0044,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "t2.small",
+    "price": 0.0044,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m1.small",
+    "price": 0.0044,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "t2.small",
+    "price": 0.0045,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "t2.small",
+    "price": 0.0045,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m1.small",
+    "price": 0.0047,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m1.small",
+    "price": 0.0047,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m1.small",
+    "price": 0.0047,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m1.small",
+    "price": 0.0047,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m1.small",
+    "price": 0.0047,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "t2.small",
+    "price": 0.006,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "t2.small",
+    "price": 0.006,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "t2.small",
+    "price": 0.0061,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "t2.small",
+    "price": 0.0061,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "t2.small",
+    "price": 0.0061,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "t2.small",
+    "price": 0.0061,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "t2.small",
+    "price": 0.0066,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "t2.small",
+    "price": 0.0066,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "t2.small",
+    "price": 0.0066,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m3.medium",
+    "price": 0.0067,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m3.medium",
+    "price": 0.0067,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m3.medium",
+    "price": 0.0067,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "t2.small",
+    "price": 0.0068,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "t2.small",
+    "price": 0.0068,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "t2.small",
+    "price": 0.0068,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "t2.small",
+    "price": 0.0069,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "t2.small",
+    "price": 0.0069,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "t2.small",
+    "price": 0.0069,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "t2.small",
+    "price": 0.0069,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "t2.small",
+    "price": 0.0069,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "t1.micro",
+    "price": 0.007,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "t2.small",
+    "price": 0.007,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "t2.small",
+    "price": 0.007,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "t2.small",
+    "price": 0.007,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m3.medium",
+    "price": 0.0073,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m3.medium",
+    "price": 0.0073,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m3.medium",
+    "price": 0.0073,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m3.medium",
+    "price": 0.0077,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m3.medium",
+    "price": 0.0077,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "m3.medium",
+    "price": 0.0079,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "m3.medium",
+    "price": 0.0079,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m1.medium",
+    "price": 0.0087,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m1.medium",
+    "price": 0.0087,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m1.medium",
+    "price": 0.0087,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m1.medium",
+    "price": 0.0087,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m1.medium",
+    "price": 0.0087,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m1.medium",
+    "price": 0.0087,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "t2.medium",
+    "price": 0.0088,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "t2.medium",
+    "price": 0.0089,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "t2.medium",
+    "price": 0.0089,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m1.medium",
+    "price": 0.0095,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m1.medium",
+    "price": 0.0095,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m1.medium",
+    "price": 0.0095,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m1.medium",
+    "price": 0.0095,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m1.medium",
+    "price": 0.0095,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "t2.medium",
+    "price": 0.012,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "t2.medium",
+    "price": 0.012,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "t2.medium",
+    "price": 0.0121,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "t2.medium",
+    "price": 0.0121,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "t2.medium",
+    "price": 0.0122,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "t2.medium",
+    "price": 0.0122,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c1.medium",
+    "price": 0.013,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "c1.medium",
+    "price": 0.013,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c1.medium",
+    "price": 0.0131,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "t2.medium",
+    "price": 0.0134,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "t2.medium",
+    "price": 0.0134,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "t2.medium",
+    "price": 0.0134,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "t2.medium",
+    "price": 0.0135,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "t2.medium",
+    "price": 0.0135,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "t2.medium",
+    "price": 0.0135,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c1.medium",
+    "price": 0.0138,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "t2.medium",
+    "price": 0.0139,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "t2.medium",
+    "price": 0.0139,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "t2.medium",
+    "price": 0.0139,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c1.medium",
+    "price": 0.0139,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "t2.medium",
+    "price": 0.0139,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "t2.medium",
+    "price": 0.0139,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c1.medium",
+    "price": 0.0141,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c1.medium",
+    "price": 0.0146,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c1.medium",
+    "price": 0.0148,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c1.medium",
+    "price": 0.0148,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c1.medium",
+    "price": 0.0148,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c1.medium",
+    "price": 0.0148,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c1.medium",
+    "price": 0.0148,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "m1.small",
+    "price": 0.0153,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "m1.large",
+    "price": 0.0175,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m1.large",
+    "price": 0.0175,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m1.large",
+    "price": 0.0175,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m1.large",
+    "price": 0.0175,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "t2.large",
+    "price": 0.0175,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "t2.large",
+    "price": 0.0175,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "t2.large",
+    "price": 0.0179,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "r4.large",
+    "price": 0.0189,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m1.large",
+    "price": 0.019,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m1.large",
+    "price": 0.019,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m1.large",
+    "price": 0.019,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m1.large",
+    "price": 0.019,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m1.large",
+    "price": 0.019,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "r4.large",
+    "price": 0.0196,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "t1.micro",
+    "price": 0.02,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "r3.large",
+    "price": 0.0206,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "r3.large",
+    "price": 0.0207,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "c4.large",
+    "price": 0.0209,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "r4.large",
+    "price": 0.021,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "r3.large",
+    "price": 0.0216,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "m4.large",
+    "price": 0.0232,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "t2.large",
+    "price": 0.0241,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "t2.large",
+    "price": 0.0241,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "t2.large",
+    "price": 0.0243,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "t2.large",
+    "price": 0.0243,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m2.xlarge",
+    "price": 0.0245,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m2.xlarge",
+    "price": 0.0245,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m2.xlarge",
+    "price": 0.0245,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "c4.large",
+    "price": 0.0246,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "t2.large",
+    "price": 0.0248,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "t2.large",
+    "price": 0.0248,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "m4.large",
+    "price": 0.0256,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "m4.large",
+    "price": 0.0257,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "c4.large",
+    "price": 0.026,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c3.large",
+    "price": 0.0261,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m2.xlarge",
+    "price": 0.0262,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "t2.large",
+    "price": 0.0267,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "t2.large",
+    "price": 0.0267,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "t2.large",
+    "price": 0.0267,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "m4.large",
+    "price": 0.027,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "m4.large",
+    "price": 0.027,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "t2.large",
+    "price": 0.0272,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "t2.large",
+    "price": 0.0272,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "t2.large",
+    "price": 0.0272,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c3.large",
+    "price": 0.0273,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c3.large",
+    "price": 0.0273,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c3.large",
+    "price": 0.0273,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c3.large",
+    "price": 0.0273,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c3.large",
+    "price": 0.0273,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c3.large",
+    "price": 0.0273,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m3.large",
+    "price": 0.0274,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m3.large",
+    "price": 0.0274,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m2.xlarge",
+    "price": 0.0275,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m2.xlarge",
+    "price": 0.0275,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m2.xlarge",
+    "price": 0.0275,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m2.xlarge",
+    "price": 0.0275,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m2.xlarge",
+    "price": 0.0275,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m5.large",
+    "price": 0.0276,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "t2.large",
+    "price": 0.0278,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "t2.large",
+    "price": 0.0278,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "t2.large",
+    "price": 0.0279,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "t2.large",
+    "price": 0.0279,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "t2.large",
+    "price": 0.0279,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "c4.large",
+    "price": 0.028,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m5.large",
+    "price": 0.0281,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c3.large",
+    "price": 0.0281,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m5.large",
+    "price": 0.0285,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c4.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c4.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c4.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m3.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c4.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c4.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "c4.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "c4.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m3.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m3.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c4.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "r3.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c4.large",
+    "price": 0.0287,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m4.large",
+    "price": 0.0288,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m4.large",
+    "price": 0.029,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c3.large",
+    "price": 0.0291,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c3.large",
+    "price": 0.0291,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c3.large",
+    "price": 0.0291,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "r3.large",
+    "price": 0.0293,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "m4.large",
+    "price": 0.0294,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "m4.large",
+    "price": 0.0294,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "m3.large",
+    "price": 0.0295,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "m3.large",
+    "price": 0.0295,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c4.large",
+    "price": 0.0296,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "r3.large",
+    "price": 0.03,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "r3.large",
+    "price": 0.03,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "r3.large",
+    "price": 0.03,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m4.large",
+    "price": 0.0301,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m4.large",
+    "price": 0.0301,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m4.large",
+    "price": 0.0301,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "r4.large",
+    "price": 0.0305,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c4.large",
+    "price": 0.0306,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c4.large",
+    "price": 0.0306,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m3.large",
+    "price": 0.0306,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c4.large",
+    "price": 0.0306,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "m1.medium",
+    "price": 0.0306,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m3.large",
+    "price": 0.0306,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "r4.large",
+    "price": 0.0309,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "r3.large",
+    "price": 0.0309,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "r3.large",
+    "price": 0.0309,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "c4.large",
+    "price": 0.0309,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "m4.large",
+    "price": 0.031,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "m4.large",
+    "price": 0.031,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "c4.large",
+    "price": 0.0312,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "m4.large",
+    "price": 0.0312,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "c4.large",
+    "price": 0.0312,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "m5.large",
+    "price": 0.0314,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "r4.large",
+    "price": 0.0315,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "r4.large",
+    "price": 0.0315,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "r3.large",
+    "price": 0.032,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "r3.large",
+    "price": 0.032,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "r3.large",
+    "price": 0.032,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "r4.large",
+    "price": 0.0321,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m4.large",
+    "price": 0.0321,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m4.large",
+    "price": 0.0321,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m4.large",
+    "price": 0.0321,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m5.large",
+    "price": 0.0322,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m5.large",
+    "price": 0.0324,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "r4.large",
+    "price": 0.0325,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "r4.large",
+    "price": 0.0325,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "r4.large",
+    "price": 0.0325,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c5.large",
+    "price": 0.0326,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "r4.large",
+    "price": 0.0328,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "c4.large",
+    "price": 0.033,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c4.large",
+    "price": 0.033,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "r4.large",
+    "price": 0.0333,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "c4.large",
+    "price": 0.0334,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "r4.large",
+    "price": 0.0336,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "r4.large",
+    "price": 0.0336,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "r4.large",
+    "price": 0.0336,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m5.large",
+    "price": 0.0342,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c3.large",
+    "price": 0.0343,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "r4.large",
+    "price": 0.0343,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m5.large",
+    "price": 0.0344,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "t2.xlarge",
+    "price": 0.0345,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "r4.large",
+    "price": 0.0346,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c5.large",
+    "price": 0.0348,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "c4.large",
+    "price": 0.0349,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m1.xlarge",
+    "price": 0.035,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "t2.xlarge",
+    "price": 0.035,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m1.xlarge",
+    "price": 0.035,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m1.xlarge",
+    "price": 0.035,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "t2.xlarge",
+    "price": 0.0352,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "r3.xlarge",
+    "price": 0.0354,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "m4.xlarge",
+    "price": 0.0355,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "m4.xlarge",
+    "price": 0.0355,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "m4.xlarge",
+    "price": 0.0355,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c5.large",
+    "price": 0.0357,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m5.large",
+    "price": 0.036,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "r3.xlarge",
+    "price": 0.0361,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c5.large",
+    "price": 0.0364,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "r3.xlarge",
+    "price": 0.0365,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "r4.large",
+    "price": 0.037,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "r4.xlarge",
+    "price": 0.0372,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "r4.xlarge",
+    "price": 0.0372,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "c3.large",
+    "price": 0.0372,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "r4.xlarge",
+    "price": 0.0372,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m5.large",
+    "price": 0.0375,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m1.xlarge",
+    "price": 0.0379,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m1.xlarge",
+    "price": 0.0379,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m1.xlarge",
+    "price": 0.0379,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m1.xlarge",
+    "price": 0.0379,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m1.xlarge",
+    "price": 0.0379,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c5.large",
+    "price": 0.0384,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m3.large",
+    "price": 0.0393,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "c4.xlarge",
+    "price": 0.0413,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "c4.xlarge",
+    "price": 0.0413,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "c4.xlarge",
+    "price": 0.0415,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c5.large",
+    "price": 0.0429,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c1.medium",
+    "price": 0.0445,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "i3.large",
+    "price": 0.0468,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "i3.large",
+    "price": 0.0468,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "i3.large",
+    "price": 0.0468,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "i3.large",
+    "price": 0.0468,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "i3.large",
+    "price": 0.047,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "i3.large",
+    "price": 0.0474,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "t2.xlarge",
+    "price": 0.0481,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "t2.xlarge",
+    "price": 0.0481,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "t2.xlarge",
+    "price": 0.0486,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "t2.xlarge",
+    "price": 0.0486,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "i3.large",
+    "price": 0.0488,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m2.2xlarge",
+    "price": 0.049,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m2.2xlarge",
+    "price": 0.049,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "c3.large",
+    "price": 0.0493,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m2.2xlarge",
+    "price": 0.0493,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "i3.large",
+    "price": 0.0495,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "t2.xlarge",
+    "price": 0.0496,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "t2.xlarge",
+    "price": 0.0496,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "i3.large",
+    "price": 0.051,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "i3.large",
+    "price": 0.0516,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "i3.large",
+    "price": 0.0516,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "i3.large",
+    "price": 0.0516,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "i3.large",
+    "price": 0.0518,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "i3.large",
+    "price": 0.0519,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c1.xlarge",
+    "price": 0.052,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c1.xlarge",
+    "price": 0.052,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c1.xlarge",
+    "price": 0.0528,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "t2.xlarge",
+    "price": 0.0535,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "t2.xlarge",
+    "price": 0.0535,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "t2.xlarge",
+    "price": 0.0535,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "m4.xlarge",
+    "price": 0.054,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "m4.xlarge",
+    "price": 0.054,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "t2.xlarge",
+    "price": 0.0544,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "t2.xlarge",
+    "price": 0.0544,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "t2.xlarge",
+    "price": 0.0544,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m3.xlarge",
+    "price": 0.0548,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c4.xlarge",
+    "price": 0.0548,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m2.2xlarge",
+    "price": 0.055,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m2.2xlarge",
+    "price": 0.055,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m2.2xlarge",
+    "price": 0.055,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m2.2xlarge",
+    "price": 0.055,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m2.2xlarge",
+    "price": 0.055,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c4.xlarge",
+    "price": 0.0551,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c3.xlarge",
+    "price": 0.0552,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m5.xlarge",
+    "price": 0.0553,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m5.xlarge",
+    "price": 0.0553,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m3.xlarge",
+    "price": 0.0554,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "c4.xlarge",
+    "price": 0.0554,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "t2.xlarge",
+    "price": 0.0557,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "t2.xlarge",
+    "price": 0.0557,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "t2.xlarge",
+    "price": 0.0557,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "t2.xlarge",
+    "price": 0.0557,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "t2.xlarge",
+    "price": 0.0557,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "t2.xlarge",
+    "price": 0.0557,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "i3.large",
+    "price": 0.0558,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "c4.xlarge",
+    "price": 0.0559,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "c4.xlarge",
+    "price": 0.0559,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c3.xlarge",
+    "price": 0.056,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "c3.xlarge",
+    "price": 0.0562,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "i3.large",
+    "price": 0.0563,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "r4.xlarge",
+    "price": 0.0566,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "i3.large",
+    "price": 0.0567,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c1.xlarge",
+    "price": 0.0568,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m5.xlarge",
+    "price": 0.0572,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m3.xlarge",
+    "price": 0.0573,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c4.xlarge",
+    "price": 0.0573,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m3.xlarge",
+    "price": 0.0573,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c4.xlarge",
+    "price": 0.0573,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c4.xlarge",
+    "price": 0.0573,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c3.xlarge",
+    "price": 0.0574,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m3.xlarge",
+    "price": 0.0577,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "r4.xlarge",
+    "price": 0.0578,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m3.xlarge",
+    "price": 0.058,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c3.xlarge",
+    "price": 0.0582,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c3.xlarge",
+    "price": 0.0582,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c3.xlarge",
+    "price": 0.0582,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m4.xlarge",
+    "price": 0.0583,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c3.xlarge",
+    "price": 0.0583,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "r3.xlarge",
+    "price": 0.0586,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "m4.xlarge",
+    "price": 0.0587,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "m4.xlarge",
+    "price": 0.0587,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "c4.xlarge",
+    "price": 0.059,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "m3.xlarge",
+    "price": 0.059,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "c4.xlarge",
+    "price": 0.059,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c1.xlarge",
+    "price": 0.0592,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c1.xlarge",
+    "price": 0.0592,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c1.xlarge",
+    "price": 0.0592,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c1.xlarge",
+    "price": 0.0592,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c1.xlarge",
+    "price": 0.0592,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "c4.xlarge",
+    "price": 0.0596,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "c5.xlarge",
+    "price": 0.0602,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c5.xlarge",
+    "price": 0.0602,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m4.xlarge",
+    "price": 0.0602,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c5.xlarge",
+    "price": 0.0602,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c5.xlarge",
+    "price": 0.0602,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m4.xlarge",
+    "price": 0.0602,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c5.xlarge",
+    "price": 0.0602,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "c5.xlarge",
+    "price": 0.0602,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m4.xlarge",
+    "price": 0.0602,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c5.xlarge",
+    "price": 0.0603,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "m3.xlarge",
+    "price": 0.0608,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m3.xlarge",
+    "price": 0.0612,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "r3.xlarge",
+    "price": 0.0612,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c4.xlarge",
+    "price": 0.0612,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c4.xlarge",
+    "price": 0.0612,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m3.xlarge",
+    "price": 0.0612,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c4.xlarge",
+    "price": 0.0612,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m3.xlarge",
+    "price": 0.0612,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m4.xlarge",
+    "price": 0.0614,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "r4.xlarge",
+    "price": 0.0615,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "r4.xlarge",
+    "price": 0.0615,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "c3.xlarge",
+    "price": 0.0615,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "r3.xlarge",
+    "price": 0.0618,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "r3.xlarge",
+    "price": 0.0618,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "m4.xlarge",
+    "price": 0.062,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c1.xlarge",
+    "price": 0.0621,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "r3.xlarge",
+    "price": 0.0625,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "m4.xlarge",
+    "price": 0.0632,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "r4.xlarge",
+    "price": 0.0633,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c5.xlarge",
+    "price": 0.0636,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "r4.xlarge",
+    "price": 0.0639,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m4.xlarge",
+    "price": 0.0642,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m4.xlarge",
+    "price": 0.0642,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m4.xlarge",
+    "price": 0.0642,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "r3.xlarge",
+    "price": 0.0644,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "r4.xlarge",
+    "price": 0.0649,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "r3.xlarge",
+    "price": 0.0661,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c3.xlarge",
+    "price": 0.0661,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c3.xlarge",
+    "price": 0.0663,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "r3.xlarge",
+    "price": 0.0664,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "r3.xlarge",
+    "price": 0.0669,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "r3.xlarge",
+    "price": 0.067,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "r4.xlarge",
+    "price": 0.0671,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "r4.xlarge",
+    "price": 0.0673,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "r4.xlarge",
+    "price": 0.0674,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "r4.xlarge",
+    "price": 0.068,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "r3.xlarge",
+    "price": 0.0689,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c1.xlarge",
+    "price": 0.0691,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "r4.xlarge",
+    "price": 0.0697,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "r3.xlarge",
+    "price": 0.0701,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "t2.2xlarge",
+    "price": 0.0706,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "r3.2xlarge",
+    "price": 0.0709,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "r3.2xlarge",
+    "price": 0.0709,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "r3.2xlarge",
+    "price": 0.0709,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "m4.2xlarge",
+    "price": 0.071,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "m4.2xlarge",
+    "price": 0.071,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "t2.2xlarge",
+    "price": 0.0711,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "r3.xlarge",
+    "price": 0.0715,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "m4.2xlarge",
+    "price": 0.0718,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "t2.2xlarge",
+    "price": 0.072,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m5.xlarge",
+    "price": 0.0723,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "r4.xlarge",
+    "price": 0.0737,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m5.xlarge",
+    "price": 0.0742,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "r4.2xlarge",
+    "price": 0.0744,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "r4.2xlarge",
+    "price": 0.0744,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "r4.2xlarge",
+    "price": 0.0744,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "m4.xlarge",
+    "price": 0.0748,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m5.xlarge",
+    "price": 0.0748,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m5.xlarge",
+    "price": 0.0749,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c3.xlarge",
+    "price": 0.0767,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "c4.2xlarge",
+    "price": 0.0767,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "c4.2xlarge",
+    "price": 0.077,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m5.xlarge",
+    "price": 0.0773,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "c4.2xlarge",
+    "price": 0.0775,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c5.xlarge",
+    "price": 0.0778,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c5.xlarge",
+    "price": 0.078,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c5.xlarge",
+    "price": 0.0785,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "m3.medium",
+    "price": 0.079,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "r4.xlarge",
+    "price": 0.0815,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "c4.xlarge",
+    "price": 0.0816,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m5.xlarge",
+    "price": 0.0821,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "m1.medium",
+    "price": 0.087,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "m5.xlarge",
+    "price": 0.0873,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "r4.xlarge",
+    "price": 0.0926,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "h1.2xlarge",
+    "price": 0.0935,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "h1.2xlarge",
+    "price": 0.0935,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "h1.2xlarge",
+    "price": 0.0935,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "i3.xlarge",
+    "price": 0.0936,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "i3.xlarge",
+    "price": 0.0936,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "i3.xlarge",
+    "price": 0.0936,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "i3.xlarge",
+    "price": 0.0936,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "i3.xlarge",
+    "price": 0.0953,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "m5.large",
+    "price": 0.096,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "i3.xlarge",
+    "price": 0.0962,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "t2.2xlarge",
+    "price": 0.0963,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "t2.2xlarge",
+    "price": 0.0963,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "i3.xlarge",
+    "price": 0.0971,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "t2.2xlarge",
+    "price": 0.0972,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "t2.2xlarge",
+    "price": 0.0972,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m2.4xlarge",
+    "price": 0.098,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m2.4xlarge",
+    "price": 0.098,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m2.4xlarge",
+    "price": 0.098,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "i3.xlarge",
+    "price": 0.0989,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "t2.2xlarge",
+    "price": 0.0993,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "t2.2xlarge",
+    "price": 0.0993,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "i3.xlarge",
+    "price": 0.1028,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "i3.xlarge",
+    "price": 0.1032,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "i3.xlarge",
+    "price": 0.1032,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "i3.xlarge",
+    "price": 0.1032,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "c3.large",
+    "price": 0.105,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "c3.large",
+    "price": 0.105,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "i3.xlarge",
+    "price": 0.1055,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "i3.xlarge",
+    "price": 0.1065,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1069,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1069,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1069,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1075,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1081,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1081,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "i3.xlarge",
+    "price": 0.1082,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "i3.xlarge",
+    "price": 0.1086,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1089,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1089,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1089,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m2.4xlarge",
+    "price": 0.11,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m2.4xlarge",
+    "price": 0.11,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m2.4xlarge",
+    "price": 0.11,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m2.4xlarge",
+    "price": 0.11,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m2.4xlarge",
+    "price": 0.11,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m5.2xlarge",
+    "price": 0.1106,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m5.2xlarge",
+    "price": 0.1106,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m5.2xlarge",
+    "price": 0.1106,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1114,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1114,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1114,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1115,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1115,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "t2.2xlarge",
+    "price": 0.1115,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "i3.xlarge",
+    "price": 0.1116,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1119,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1123,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1132,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "r4.2xlarge",
+    "price": 0.114,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1144,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1146,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1146,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1146,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1146,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1146,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1146,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1146,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1146,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1148,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1154,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1174,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "m3.2xlarge",
+    "price": 0.118,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1184,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1185,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1192,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "m5.2xlarge",
+    "price": 0.1196,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1201,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1201,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1202,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1204,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c5.2xlarge",
+    "price": 0.1204,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1204,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1204,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c5.2xlarge",
+    "price": 0.1204,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1208,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1209,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c5.2xlarge",
+    "price": 0.1214,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1218,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1223,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1223,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1223,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1223,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1223,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1223,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "r4.2xlarge",
+    "price": 0.123,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "r4.2xlarge",
+    "price": 0.123,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "r4.xlarge",
+    "price": 0.123,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1235,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1237,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1237,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1239,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1239,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1241,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1243,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1243,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c5.2xlarge",
+    "price": 0.1244,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1247,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1251,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1258,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1261,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1261,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1262,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1269,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1273,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1275,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1276,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1277,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1279,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1279,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1279,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1282,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1284,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1284,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1284,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1286,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1286,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c5.2xlarge",
+    "price": 0.129,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1298,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1298,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1304,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1314,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1317,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m5.2xlarge",
+    "price": 0.132,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m3.2xlarge",
+    "price": 0.1331,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "i3.xlarge",
+    "price": 0.1332,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m5.2xlarge",
+    "price": 0.1334,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1335,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m5.2xlarge",
+    "price": 0.1336,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m5.2xlarge",
+    "price": 0.1339,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1345,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1345,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1345,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1349,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c5.2xlarge",
+    "price": 0.1349,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1356,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "c5.2xlarge",
+    "price": 0.1356,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c3.2xlarge",
+    "price": 0.1368,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1371,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1372,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "c5.2xlarge",
+    "price": 0.1392,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1394,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "r3.2xlarge",
+    "price": 0.14,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1406,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1406,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1407,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1407,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "r3.2xlarge",
+    "price": 0.141,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1412,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1413,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c5.2xlarge",
+    "price": 0.1414,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "r3.4xlarge",
+    "price": 0.1418,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m4.2xlarge",
+    "price": 0.1418,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1421,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1428,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m5.2xlarge",
+    "price": 0.1437,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "r3.4xlarge",
+    "price": 0.1437,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1445,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "m4.4xlarge",
+    "price": 0.1462,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "c4.2xlarge",
+    "price": 0.1463,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1467,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "r3.4xlarge",
+    "price": 0.1484,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "r4.4xlarge",
+    "price": 0.1489,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "r4.4xlarge",
+    "price": 0.1489,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m5.2xlarge",
+    "price": 0.149,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "r4.4xlarge",
+    "price": 0.152,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "r4.2xlarge",
+    "price": 0.1526,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "m4.4xlarge",
+    "price": 0.1537,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "m4.4xlarge",
+    "price": 0.1541,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "c4.4xlarge",
+    "price": 0.1558,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "c4.4xlarge",
+    "price": 0.1572,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c5.2xlarge",
+    "price": 0.1576,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "m3.large",
+    "price": 0.158,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "h1.2xlarge",
+    "price": 0.1584,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "h1.2xlarge",
+    "price": 0.1584,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "r3.2xlarge",
+    "price": 0.1644,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c5.2xlarge",
+    "price": 0.1649,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "h1.2xlarge",
+    "price": 0.165,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "h1.2xlarge",
+    "price": 0.165,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "h1.2xlarge",
+    "price": 0.165,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "c4.4xlarge",
+    "price": 0.1662,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1692,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c5.xlarge",
+    "price": 0.17,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "i3.large",
+    "price": 0.172,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "m1.large",
+    "price": 0.175,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m2.4xlarge",
+    "price": 0.1755,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1789,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "i3.large",
+    "price": 0.181,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "h1.4xlarge",
+    "price": 0.187,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "h1.4xlarge",
+    "price": 0.187,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "h1.4xlarge",
+    "price": 0.187,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1872,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1872,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1872,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1872,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1872,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1872,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1872,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1872,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1872,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1872,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "i3.2xlarge",
+    "price": 0.1913,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "d2.xlarge",
+    "price": 0.1921,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "r3.large",
+    "price": 0.2,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "d2.xlarge",
+    "price": 0.2006,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "d2.xlarge",
+    "price": 0.2041,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "d2.xlarge",
+    "price": 0.2048,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2059,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "i3.2xlarge",
+    "price": 0.2064,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "i3.2xlarge",
+    "price": 0.2064,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "d2.xlarge",
+    "price": 0.2068,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "d2.xlarge",
+    "price": 0.207,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "d2.xlarge",
+    "price": 0.207,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "d2.xlarge",
+    "price": 0.207,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "d2.xlarge",
+    "price": 0.207,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "d2.xlarge",
+    "price": 0.207,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2111,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "d2.xlarge",
+    "price": 0.2145,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "d2.xlarge",
+    "price": 0.2152,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2162,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2162,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "i3.2xlarge",
+    "price": 0.2172,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "d2.xlarge",
+    "price": 0.2205,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "d2.xlarge",
+    "price": 0.2205,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "d2.xlarge",
+    "price": 0.2205,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "cc2.8xlarge",
+    "price": 0.2215,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c3.4xlarge",
+    "price": 0.2218,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "i2.xlarge",
+    "price": 0.2227,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "cc2.8xlarge",
+    "price": 0.2228,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "i3.2xlarge",
+    "price": 0.2232,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "i3.2xlarge",
+    "price": 0.2232,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "i3.2xlarge",
+    "price": 0.2232,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2237,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2237,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "i2.xlarge",
+    "price": 0.2244,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "h1.2xlarge",
+    "price": 0.2254,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "i2.xlarge",
+    "price": 0.2279,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2292,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2292,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2292,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2292,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2301,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2303,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m5.4xlarge",
+    "price": 0.2311,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m5.4xlarge",
+    "price": 0.2311,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m5.4xlarge",
+    "price": 0.2311,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m5.4xlarge",
+    "price": 0.2311,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c3.4xlarge",
+    "price": 0.2328,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c3.4xlarge",
+    "price": 0.233,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c3.4xlarge",
+    "price": 0.2336,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c3.4xlarge",
+    "price": 0.2341,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2349,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2349,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "x1e.xlarge",
+    "price": 0.2351,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2361,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2361,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2361,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "x1e.xlarge",
+    "price": 0.2381,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "d2.xlarge",
+    "price": 0.2382,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "d2.xlarge",
+    "price": 0.2382,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m5.4xlarge",
+    "price": 0.2405,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2407,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2407,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "i2.xlarge",
+    "price": 0.2415,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "r4.2xlarge",
+    "price": 0.2429,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "g2.2xlarge",
+    "price": 0.243,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "g2.2xlarge",
+    "price": 0.2431,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "m5.4xlarge",
+    "price": 0.2433,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "x1e.xlarge",
+    "price": 0.2443,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2446,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2446,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2446,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2462,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c5.4xlarge",
+    "price": 0.2463,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "c3.4xlarge",
+    "price": 0.2463,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "i2.xlarge",
+    "price": 0.2465,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2466,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2468,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "r3.4xlarge",
+    "price": 0.2473,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "r3.4xlarge",
+    "price": 0.2473,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2479,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2479,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2479,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "g2.2xlarge",
+    "price": 0.2481,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2491,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "h1.2xlarge",
+    "price": 0.2498,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "g2.2xlarge",
+    "price": 0.25,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "x1e.xlarge",
+    "price": 0.2502,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "x1e.xlarge",
+    "price": 0.2502,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2503,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "g2.2xlarge",
+    "price": 0.2509,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m5.4xlarge",
+    "price": 0.2517,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2522,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2527,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m5.4xlarge",
+    "price": 0.2535,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "i2.xlarge",
+    "price": 0.254,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c3.4xlarge",
+    "price": 0.2542,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2553,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "i2.xlarge",
+    "price": 0.2556,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "i2.xlarge",
+    "price": 0.2559,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "i2.xlarge",
+    "price": 0.2559,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "i2.xlarge",
+    "price": 0.2559,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "i2.xlarge",
+    "price": 0.2559,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "i2.xlarge",
+    "price": 0.2559,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2565,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c5.4xlarge",
+    "price": 0.2569,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2569,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2569,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2569,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "g2.2xlarge",
+    "price": 0.2573,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c5.4xlarge",
+    "price": 0.2584,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2591,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c5.4xlarge",
+    "price": 0.2593,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2596,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2597,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2597,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2616,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "g2.2xlarge",
+    "price": 0.2636,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2637,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m4.4xlarge",
+    "price": 0.2645,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c5.4xlarge",
+    "price": 0.2649,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c4.4xlarge",
+    "price": 0.2655,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2662,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c3.4xlarge",
+    "price": 0.2675,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "r3.4xlarge",
+    "price": 0.268,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "r3.4xlarge",
+    "price": 0.2685,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m5.4xlarge",
+    "price": 0.2688,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2691,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2691,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2691,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c5.4xlarge",
+    "price": 0.2692,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c3.4xlarge",
+    "price": 0.27,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c3.4xlarge",
+    "price": 0.2705,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "r3.4xlarge",
+    "price": 0.2712,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2717,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2722,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c3.4xlarge",
+    "price": 0.273,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2738,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "r3.4xlarge",
+    "price": 0.2738,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c5.4xlarge",
+    "price": 0.2762,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "g2.2xlarge",
+    "price": 0.279,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "cc2.8xlarge",
+    "price": 0.2808,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "i2.xlarge",
+    "price": 0.2814,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "i2.xlarge",
+    "price": 0.2814,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "i2.xlarge",
+    "price": 0.2814,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "i2.xlarge",
+    "price": 0.2814,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "i2.xlarge",
+    "price": 0.2814,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2828,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "x1e.xlarge",
+    "price": 0.2837,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2858,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c3.4xlarge",
+    "price": 0.2859,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2862,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "r3.4xlarge",
+    "price": 0.2874,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "r3.4xlarge",
+    "price": 0.2893,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "i3.2xlarge",
+    "price": 0.2902,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "r3.4xlarge",
+    "price": 0.2926,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "g2.2xlarge",
+    "price": 0.2953,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "r4.8xlarge",
+    "price": 0.2977,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "g2.2xlarge",
+    "price": 0.2995,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "r4.4xlarge",
+    "price": 0.2998,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "x1e.xlarge",
+    "price": 0.3,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "g2.2xlarge",
+    "price": 0.301,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "r3.4xlarge",
+    "price": 0.3015,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "r3.4xlarge",
+    "price": 0.3024,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "cc2.8xlarge",
+    "price": 0.3027,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "i2.xlarge",
+    "price": 0.3039,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "i2.xlarge",
+    "price": 0.3039,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "r4.4xlarge",
+    "price": 0.304,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "d2.xlarge",
+    "price": 0.3053,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "r4.4xlarge",
+    "price": 0.3105,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "g2.2xlarge",
+    "price": 0.3107,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "g2.2xlarge",
+    "price": 0.3114,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "p2.xlarge",
+    "price": 0.3148,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "m3.xlarge",
+    "price": 0.315,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "h1.4xlarge",
+    "price": 0.3168,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "h1.4xlarge",
+    "price": 0.3168,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c5.4xlarge",
+    "price": 0.3193,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "i3.4xlarge",
+    "price": 0.3198,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "i3.4xlarge",
+    "price": 0.3201,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c5.4xlarge",
+    "price": 0.3202,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "i3.4xlarge",
+    "price": 0.3204,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "r3.8xlarge",
+    "price": 0.321,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "r3.8xlarge",
+    "price": 0.3213,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "c4.8xlarge",
+    "price": 0.3228,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "c4.8xlarge",
+    "price": 0.3259,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "p2.xlarge",
+    "price": 0.3273,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "c4.8xlarge",
+    "price": 0.3292,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "h1.4xlarge",
+    "price": 0.3299,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "h1.4xlarge",
+    "price": 0.3299,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "h1.4xlarge",
+    "price": 0.33,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "h1.4xlarge",
+    "price": 0.33,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "p2.xlarge",
+    "price": 0.3312,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "p2.xlarge",
+    "price": 0.3314,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "p2.xlarge",
+    "price": 0.3317,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "p2.xlarge",
+    "price": 0.3328,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "p2.xlarge",
+    "price": 0.333,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "p2.xlarge",
+    "price": 0.3343,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "cc2.8xlarge",
+    "price": 0.3344,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "r3.4xlarge",
+    "price": 0.3368,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m2.4xlarge",
+    "price": 0.342,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "r4.8xlarge",
+    "price": 0.3422,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "i3.xlarge",
+    "price": 0.344,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "r4.4xlarge",
+    "price": 0.3451,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "p2.xlarge",
+    "price": 0.3451,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m5.4xlarge",
+    "price": 0.3473,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "cr1.8xlarge",
+    "price": 0.35,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "cr1.8xlarge",
+    "price": 0.35,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "cr1.8xlarge",
+    "price": 0.35,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "r3.8xlarge",
+    "price": 0.3531,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "p2.xlarge",
+    "price": 0.3535,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "p2.xlarge",
+    "price": 0.3577,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "r3.4xlarge",
+    "price": 0.3585,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "i3.xlarge",
+    "price": 0.362,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "r4.8xlarge",
+    "price": 0.3685,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "m4.10xlarge",
+    "price": 0.3732,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "h1.8xlarge",
+    "price": 0.374,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "h1.8xlarge",
+    "price": 0.374,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "h1.8xlarge",
+    "price": 0.374,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "i3.4xlarge",
+    "price": 0.3744,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "i3.4xlarge",
+    "price": 0.3744,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "i3.4xlarge",
+    "price": 0.3744,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "cr1.8xlarge",
+    "price": 0.375,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "cr1.8xlarge",
+    "price": 0.375,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "cr1.8xlarge",
+    "price": 0.375,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "m4.10xlarge",
+    "price": 0.3758,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "p2.xlarge",
+    "price": 0.3813,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "m5.2xlarge",
+    "price": 0.384,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "i3.4xlarge",
+    "price": 0.3852,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "d2.2xlarge",
+    "price": 0.3886,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "i3.2xlarge",
+    "price": 0.3903,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "d2.2xlarge",
+    "price": 0.3926,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "p2.xlarge",
+    "price": 0.3939,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "d2.2xlarge",
+    "price": 0.3949,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "c3.4xlarge",
+    "price": 0.3975,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "p2.xlarge",
+    "price": 0.3978,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "d2.2xlarge",
+    "price": 0.3983,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "r3.xlarge",
+    "price": 0.4,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "p2.xlarge",
+    "price": 0.4018,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "d2.2xlarge",
+    "price": 0.4049,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4054,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "d2.2xlarge",
+    "price": 0.406,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "d2.2xlarge",
+    "price": 0.4061,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "d2.2xlarge",
+    "price": 0.4096,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4104,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4118,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "i3.4xlarge",
+    "price": 0.4128,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "i3.4xlarge",
+    "price": 0.4128,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "i3.4xlarge",
+    "price": 0.4128,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "d2.2xlarge",
+    "price": 0.414,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "d2.2xlarge",
+    "price": 0.414,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "d2.2xlarge",
+    "price": 0.414,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "d2.2xlarge",
+    "price": 0.414,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4154,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4168,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "m4.10xlarge",
+    "price": 0.4194,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "i3.4xlarge",
+    "price": 0.4198,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "c3.2xlarge",
+    "price": 0.42,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "c3.2xlarge",
+    "price": 0.42,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "i3.4xlarge",
+    "price": 0.4248,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "i3.4xlarge",
+    "price": 0.4248,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4275,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "g2.2xlarge",
+    "price": 0.4275,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4276,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "p2.xlarge",
+    "price": 0.4289,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "i3.4xlarge",
+    "price": 0.4344,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4348,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c3.8xlarge",
+    "price": 0.4367,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c3.8xlarge",
+    "price": 0.4367,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4377,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "d2.2xlarge",
+    "price": 0.4379,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4382,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "r4.4xlarge",
+    "price": 0.4384,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "d2.2xlarge",
+    "price": 0.441,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "d2.2xlarge",
+    "price": 0.441,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "d2.2xlarge",
+    "price": 0.441,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "i3.4xlarge",
+    "price": 0.4423,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4429,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "d2.2xlarge",
+    "price": 0.444,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4455,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4461,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "i3.4xlarge",
+    "price": 0.4464,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "h1.4xlarge",
+    "price": 0.4464,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c3.8xlarge",
+    "price": 0.447,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4474,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c3.8xlarge",
+    "price": 0.4488,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c3.8xlarge",
+    "price": 0.4507,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "r4.8xlarge",
+    "price": 0.4529,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "r4.8xlarge",
+    "price": 0.4529,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c3.8xlarge",
+    "price": 0.4533,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "cc2.8xlarge",
+    "price": 0.4535,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "x1e.2xlarge",
+    "price": 0.455,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4585,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4585,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4585,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4587,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "r3.8xlarge",
+    "price": 0.4591,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "r3.8xlarge",
+    "price": 0.4591,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "i2.2xlarge",
+    "price": 0.4626,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "d2.2xlarge",
+    "price": 0.4632,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c3.8xlarge",
+    "price": 0.4659,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c3.8xlarge",
+    "price": 0.4659,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "i2.2xlarge",
+    "price": 0.4677,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "f1.2xlarge",
+    "price": 0.4702,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4715,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4722,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4722,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "g3.4xlarge",
+    "price": 0.4727,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "i2.2xlarge",
+    "price": 0.4805,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "r4.8xlarge",
+    "price": 0.4821,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "i2.2xlarge",
+    "price": 0.4828,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "r4.8xlarge",
+    "price": 0.483,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4838,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4847,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4892,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "i2.2xlarge",
+    "price": 0.49,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c4.8xlarge",
+    "price": 0.49,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "c3.8xlarge",
+    "price": 0.4907,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "h1.4xlarge",
+    "price": 0.4907,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "r4.8xlarge",
+    "price": 0.4922,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "r4.8xlarge",
+    "price": 0.4922,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c4.8xlarge",
+    "price": 0.4977,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "x1e.2xlarge",
+    "price": 0.5004,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "x1e.2xlarge",
+    "price": 0.5004,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "r4.4xlarge",
+    "price": 0.5013,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c3.4xlarge",
+    "price": 0.5015,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c3.8xlarge",
+    "price": 0.5026,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5044,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "hi1.4xlarge",
+    "price": 0.5048,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "c5.4xlarge",
+    "price": 0.5051,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "f1.2xlarge",
+    "price": 0.5052,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "i3.4xlarge",
+    "price": 0.5073,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5084,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "x1e.2xlarge",
+    "price": 0.5093,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "f1.2xlarge",
+    "price": 0.5099,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "f1.2xlarge",
+    "price": 0.51,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5115,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5115,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5115,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5115,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "g3.4xlarge",
+    "price": 0.5138,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "f1.2xlarge",
+    "price": 0.5143,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c3.8xlarge",
+    "price": 0.5237,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5237,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "r4.8xlarge",
+    "price": 0.525,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "r4.8xlarge",
+    "price": 0.5254,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "x1e.2xlarge",
+    "price": 0.5275,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "r4.8xlarge",
+    "price": 0.5295,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5303,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5311,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "d2.2xlarge",
+    "price": 0.5312,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "r4.8xlarge",
+    "price": 0.5312,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "r4.8xlarge",
+    "price": 0.5333,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5339,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "r4.8xlarge",
+    "price": 0.5355,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "m4.10xlarge",
+    "price": 0.5404,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "m4.10xlarge",
+    "price": 0.5408,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c5.9xlarge",
+    "price": 0.5416,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c5.9xlarge",
+    "price": 0.5416,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5432,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5439,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5499,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5509,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "c4.8xlarge",
+    "price": 0.5524,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "r4.8xlarge",
+    "price": 0.5544,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5582,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "f1.2xlarge",
+    "price": 0.5584,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5618,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5628,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5628,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "i2.2xlarge",
+    "price": 0.5628,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c5.9xlarge",
+    "price": 0.5668,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5678,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "m4.16xlarge",
+    "price": 0.5683,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5718,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "r4.8xlarge",
+    "price": 0.5734,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5748,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "m4.16xlarge",
+    "price": 0.5755,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "m4.16xlarge",
+    "price": 0.5778,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "f1.2xlarge",
+    "price": 0.5792,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "g3.4xlarge",
+    "price": 0.5807,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "f1.2xlarge",
+    "price": 0.5811,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "r4.8xlarge",
+    "price": 0.5849,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5855,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "r4.8xlarge",
+    "price": 0.5864,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "m4.10xlarge",
+    "price": 0.5873,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "m4.10xlarge",
+    "price": 0.5873,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "r3.8xlarge",
+    "price": 0.5891,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c5.9xlarge",
+    "price": 0.5945,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "r4.8xlarge",
+    "price": 0.5951,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "r4.16xlarge",
+    "price": 0.5954,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "r4.16xlarge",
+    "price": 0.5954,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "r4.16xlarge",
+    "price": 0.5954,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "c3.8xlarge",
+    "price": 0.5964,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "r4.8xlarge",
+    "price": 0.6,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m4.10xlarge",
+    "price": 0.6018,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m4.10xlarge",
+    "price": 0.6018,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m4.10xlarge",
+    "price": 0.6018,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m4.10xlarge",
+    "price": 0.6018,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "d2.2xlarge",
+    "price": 0.6092,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "d2.2xlarge",
+    "price": 0.6101,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "r4.8xlarge",
+    "price": 0.613,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m4.10xlarge",
+    "price": 0.6205,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c5.9xlarge",
+    "price": 0.6235,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "i3.2xlarge",
+    "price": 0.624,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "c3.8xlarge",
+    "price": 0.6264,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "c5.9xlarge",
+    "price": 0.6274,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c5.9xlarge",
+    "price": 0.6278,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "m3.2xlarge",
+    "price": 0.632,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "h1.8xlarge",
+    "price": 0.6336,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "h1.8xlarge",
+    "price": 0.6336,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "r3.4xlarge",
+    "price": 0.6346,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "x1e.2xlarge",
+    "price": 0.6398,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "d2.2xlarge",
+    "price": 0.6511,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "f1.2xlarge",
+    "price": 0.6574,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "h1.8xlarge",
+    "price": 0.6599,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "h1.8xlarge",
+    "price": 0.6599,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "h1.8xlarge",
+    "price": 0.66,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "m4.10xlarge",
+    "price": 0.6609,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m5.12xlarge",
+    "price": 0.6636,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m4.10xlarge",
+    "price": 0.6638,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "r3.2xlarge",
+    "price": 0.665,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "r3.2xlarge",
+    "price": 0.665,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "f1.2xlarge",
+    "price": 0.6667,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m4.10xlarge",
+    "price": 0.6685,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "g3.4xlarge",
+    "price": 0.6712,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c5.9xlarge",
+    "price": 0.6787,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "i3.2xlarge",
+    "price": 0.688,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "g3.8xlarge",
+    "price": 0.6979,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "f1.2xlarge",
+    "price": 0.698,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "i3.8xlarge",
+    "price": 0.7077,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "i3.8xlarge",
+    "price": 0.7108,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "i2.2xlarge",
+    "price": 0.7183,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "i3.2xlarge",
+    "price": 0.724,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m5.12xlarge",
+    "price": 0.7299,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "m5.12xlarge",
+    "price": 0.7299,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m5.12xlarge",
+    "price": 0.7299,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "r4.8xlarge",
+    "price": 0.7384,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "i3.8xlarge",
+    "price": 0.7402,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "h1.16xlarge",
+    "price": 0.748,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "i3.8xlarge",
+    "price": 0.7488,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "i3.8xlarge",
+    "price": 0.7488,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "i3.8xlarge",
+    "price": 0.7488,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "i3.8xlarge",
+    "price": 0.75,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "h1.16xlarge",
+    "price": 0.7527,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "i3.8xlarge",
+    "price": 0.7531,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m5.12xlarge",
+    "price": 0.7569,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "g3.8xlarge",
+    "price": 0.7662,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "m5.4xlarge",
+    "price": 0.768,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "g3.8xlarge",
+    "price": 0.7702,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m5.12xlarge",
+    "price": 0.771,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "g3.8xlarge",
+    "price": 0.7722,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "g3.8xlarge",
+    "price": 0.775,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "g3.8xlarge",
+    "price": 0.7771,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "d2.4xlarge",
+    "price": 0.7812,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "g3.8xlarge",
+    "price": 0.7849,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "c3.8xlarge",
+    "price": 0.7855,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "d2.4xlarge",
+    "price": 0.7862,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "i3.8xlarge",
+    "price": 0.7882,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "g3.8xlarge",
+    "price": 0.79,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "g3.8xlarge",
+    "price": 0.7966,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "r3.2xlarge",
+    "price": 0.8,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "i3.8xlarge",
+    "price": 0.8025,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "g2.8xlarge",
+    "price": 0.8062,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "i3.8xlarge",
+    "price": 0.8086,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "g3.8xlarge",
+    "price": 0.8122,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "i3.8xlarge",
+    "price": 0.8256,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "i3.8xlarge",
+    "price": 0.8256,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "i3.8xlarge",
+    "price": 0.8256,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "i3.8xlarge",
+    "price": 0.8256,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "d2.4xlarge",
+    "price": 0.828,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "d2.4xlarge",
+    "price": 0.828,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "d2.4xlarge",
+    "price": 0.828,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "d2.4xlarge",
+    "price": 0.828,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "d2.4xlarge",
+    "price": 0.828,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "d2.4xlarge",
+    "price": 0.828,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "d2.4xlarge",
+    "price": 0.828,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "d2.4xlarge",
+    "price": 0.828,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "d2.4xlarge",
+    "price": 0.828,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "d2.4xlarge",
+    "price": 0.828,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "d2.4xlarge",
+    "price": 0.828,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m5.12xlarge",
+    "price": 0.8319,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "d2.4xlarge",
+    "price": 0.8374,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "c3.4xlarge",
+    "price": 0.84,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "c3.4xlarge",
+    "price": 0.84,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "g2.8xlarge",
+    "price": 0.8424,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m5.12xlarge",
+    "price": 0.8478,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "x1e.4xlarge",
+    "price": 0.8527,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "m4.10xlarge",
+    "price": 0.8639,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "m4.16xlarge",
+    "price": 0.8646,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "m4.16xlarge",
+    "price": 0.8646,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "g2.8xlarge",
+    "price": 0.8662,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "x1e.4xlarge",
+    "price": 0.8728,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c5.9xlarge",
+    "price": 0.8757,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "g3.8xlarge",
+    "price": 0.8787,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "d2.4xlarge",
+    "price": 0.882,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "d2.4xlarge",
+    "price": 0.882,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "d2.4xlarge",
+    "price": 0.882,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "r4.16xlarge",
+    "price": 0.9058,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "r4.16xlarge",
+    "price": 0.9058,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "g2.8xlarge",
+    "price": 0.9125,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "x1e.4xlarge",
+    "price": 0.9244,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "d2.4xlarge",
+    "price": 0.9261,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "d2.4xlarge",
+    "price": 0.9261,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "m4.10xlarge",
+    "price": 0.9306,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "x1e.4xlarge",
+    "price": 0.9313,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "g2.8xlarge",
+    "price": 0.934,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "m4.16xlarge",
+    "price": 0.9396,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "m4.16xlarge",
+    "price": 0.9396,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m5.12xlarge",
+    "price": 0.9481,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "g2.8xlarge",
+    "price": 0.9488,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "d2.2xlarge",
+    "price": 0.9489,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "d2.4xlarge",
+    "price": 0.9528,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m4.10xlarge",
+    "price": 0.9563,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "x1e.4xlarge",
+    "price": 0.9583,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m4.16xlarge",
+    "price": 0.9628,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m4.16xlarge",
+    "price": 0.9628,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m4.16xlarge",
+    "price": 0.9628,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "h1.8xlarge",
+    "price": 0.9636,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m5.12xlarge",
+    "price": 0.9686,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "d2.4xlarge",
+    "price": 0.9699,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "r4.8xlarge",
+    "price": 0.97,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "i3.8xlarge",
+    "price": 0.975,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m4.10xlarge",
+    "price": 0.982,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "g2.8xlarge",
+    "price": 0.9822,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "r4.16xlarge",
+    "price": 0.9844,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "m4.16xlarge",
+    "price": 0.9916,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m4.10xlarge",
+    "price": 0.9932,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "i2.4xlarge",
+    "price": 0.9959,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "g2.8xlarge",
+    "price": 0.9976,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "i2.4xlarge",
+    "price": 1.0052,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "i3.8xlarge",
+    "price": 1.0085,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "r4.16xlarge",
+    "price": 1.0097,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "r4.16xlarge",
+    "price": 1.0114,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "i2.xlarge",
+    "price": 1.013,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "i2.4xlarge",
+    "price": 1.023,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "i2.4xlarge",
+    "price": 1.023,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "i2.4xlarge",
+    "price": 1.023,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "x1e.4xlarge",
+    "price": 1.0257,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m4.16xlarge",
+    "price": 1.0274,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m4.16xlarge",
+    "price": 1.0274,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "x1e.4xlarge",
+    "price": 1.0301,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "i2.4xlarge",
+    "price": 1.032,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "r4.16xlarge",
+    "price": 1.033,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "r4.16xlarge",
+    "price": 1.0379,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "m4.16xlarge",
+    "price": 1.0495,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "r4.16xlarge",
+    "price": 1.0509,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "r4.16xlarge",
+    "price": 1.0518,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "i3.8xlarge",
+    "price": 1.0533,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m4.16xlarge",
+    "price": 1.0555,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "g2.8xlarge",
+    "price": 1.0613,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "p3.2xlarge",
+    "price": 1.0654,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "m4.16xlarge",
+    "price": 1.0731,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "c5.18xlarge",
+    "price": 1.0832,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "c5.18xlarge",
+    "price": 1.0832,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "c5.18xlarge",
+    "price": 1.0832,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "c5.18xlarge",
+    "price": 1.0832,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "c5.18xlarge",
+    "price": 1.0832,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "c5.18xlarge",
+    "price": 1.0832,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "c5.18xlarge",
+    "price": 1.0832,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "i3.8xlarge",
+    "price": 1.105,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "m4.16xlarge",
+    "price": 1.1136,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "g2.8xlarge",
+    "price": 1.1202,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "i2.4xlarge",
+    "price": 1.1253,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "i2.4xlarge",
+    "price": 1.1303,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "g3.4xlarge",
+    "price": 1.14,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "i2.4xlarge",
+    "price": 1.1411,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "r4.16xlarge",
+    "price": 1.1415,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "g2.8xlarge",
+    "price": 1.1785,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "i2.4xlarge",
+    "price": 1.1877,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "c5.18xlarge",
+    "price": 1.1956,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "g3.4xlarge",
+    "price": 1.21,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "r4.16xlarge",
+    "price": 1.2129,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "c5.18xlarge",
+    "price": 1.2138,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "i2.4xlarge",
+    "price": 1.2149,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "r4.16xlarge",
+    "price": 1.2189,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "i2.4xlarge",
+    "price": 1.237,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "r4.16xlarge",
+    "price": 1.2502,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "h1.16xlarge",
+    "price": 1.2672,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "h1.16xlarge",
+    "price": 1.2672,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "d2.4xlarge",
+    "price": 1.2696,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "c5.18xlarge",
+    "price": 1.2744,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "c3.large",
+    "price": 1.29,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "i2.4xlarge",
+    "price": 1.3134,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "h1.16xlarge",
+    "price": 1.3198,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "h1.16xlarge",
+    "price": 1.3198,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "h1.16xlarge",
+    "price": 1.32,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "h1.16xlarge",
+    "price": 1.32,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "m5.24xlarge",
+    "price": 1.3271,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "m5.24xlarge",
+    "price": 1.3271,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "r3.4xlarge",
+    "price": 1.33,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "r3.4xlarge",
+    "price": 1.33,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "cr1.8xlarge",
+    "price": 1.3698,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "i2.4xlarge",
+    "price": 1.3702,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "i3.4xlarge",
+    "price": 1.376,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "m5.24xlarge",
+    "price": 1.3867,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "m5.24xlarge",
+    "price": 1.3867,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "h1.8xlarge",
+    "price": 1.3938,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "d2.4xlarge",
+    "price": 1.3965,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "g3.16xlarge",
+    "price": 1.4004,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "i3.4xlarge",
+    "price": 1.448,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "m5.24xlarge",
+    "price": 1.457,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "m5.24xlarge",
+    "price": 1.4598,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "m5.24xlarge",
+    "price": 1.4598,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "m5.24xlarge",
+    "price": 1.4646,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "m5.24xlarge",
+    "price": 1.466,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "r4.16xlarge",
+    "price": 1.4751,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "d2.8xlarge",
+    "price": 1.4855,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "h1.16xlarge",
+    "price": 1.4912,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "m5.24xlarge",
+    "price": 1.4971,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "i3.16xlarge",
+    "price": 1.4976,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "i3.16xlarge",
+    "price": 1.4976,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "i2.4xlarge",
+    "price": 1.5448,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "i2.4xlarge",
+    "price": 1.5751,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "p3.2xlarge",
+    "price": 1.5908,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "r3.4xlarge",
+    "price": 1.6,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "d2.8xlarge",
+    "price": 1.6108,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "m4.16xlarge",
+    "price": 1.6189,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "c5.18xlarge",
+    "price": 1.6455,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "i3.16xlarge",
+    "price": 1.6477,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "g3.16xlarge",
+    "price": 1.6479,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "i3.16xlarge",
+    "price": 1.6512,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "i3.16xlarge",
+    "price": 1.6512,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "i3.16xlarge",
+    "price": 1.6512,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "d2.8xlarge",
+    "price": 1.656,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "d2.8xlarge",
+    "price": 1.656,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "d2.8xlarge",
+    "price": 1.656,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "d2.8xlarge",
+    "price": 1.656,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "d2.8xlarge",
+    "price": 1.656,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "g3.16xlarge",
+    "price": 1.6763,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "p3.2xlarge",
+    "price": 1.6939,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "d2.8xlarge",
+    "price": 1.6972,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "g3.16xlarge",
+    "price": 1.7013,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "d2.8xlarge",
+    "price": 1.7334,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "d2.8xlarge",
+    "price": 1.764,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "d2.8xlarge",
+    "price": 1.764,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "d2.8xlarge",
+    "price": 1.764,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "h1.16xlarge",
+    "price": 1.7839,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "d2.8xlarge",
+    "price": 1.8146,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "d2.8xlarge",
+    "price": 1.8466,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "r4.16xlarge",
+    "price": 1.8528,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "p3.2xlarge",
+    "price": 1.8727,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "d2.8xlarge",
+    "price": 1.875,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "d2.8xlarge",
+    "price": 1.875,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "g3.16xlarge",
+    "price": 1.9257,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "h1.16xlarge",
+    "price": 1.9376,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "r4.16xlarge",
+    "price": 1.9656,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "g3.16xlarge",
+    "price": 1.984,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "i2.8xlarge",
+    "price": 1.991,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "i2.8xlarge",
+    "price": 1.9917,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "i3.16xlarge",
+    "price": 1.9986,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "x1.16xlarge",
+    "price": 2.0007,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "x1.16xlarge",
+    "price": 2.0007,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "x1.16xlarge",
+    "price": 2.0007,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "x1.16xlarge",
+    "price": 2.0019,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "i2.8xlarge",
+    "price": 2.034,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "i2.8xlarge",
+    "price": 2.046,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "i2.8xlarge",
+    "price": 2.046,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "x1.16xlarge",
+    "price": 2.0518,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "i3.16xlarge",
+    "price": 2.0596,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "c3.8xlarge",
+    "price": 2.064,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "i2.8xlarge",
+    "price": 2.0673,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "x1.16xlarge",
+    "price": 2.0688,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "d2.8xlarge",
+    "price": 2.1076,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "p3.2xlarge",
+    "price": 2.1076,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "p3.2xlarge",
+    "price": 2.1098,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "i3.16xlarge",
+    "price": 2.1512,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "p2.8xlarge",
+    "price": 2.16,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "x1.16xlarge",
+    "price": 2.2008,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "i3.16xlarge",
+    "price": 2.2086,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "g3.8xlarge",
+    "price": 2.2347,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "cc2.8xlarge",
+    "price": 2.25,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "cc2.8xlarge",
+    "price": 2.25,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "cc2.8xlarge",
+    "price": 2.25,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "i2.8xlarge",
+    "price": 2.2506,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "i2.8xlarge",
+    "price": 2.2506,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "g3.8xlarge",
+    "price": 2.28,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "m5.12xlarge",
+    "price": 2.304,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "p3.2xlarge",
+    "price": 2.3179,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "i3.8xlarge",
+    "price": 2.3275,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "x1.16xlarge",
+    "price": 2.3546,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "x1.16xlarge",
+    "price": 2.359,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "x1.16xlarge",
+    "price": 2.3837,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "x1.16xlarge",
+    "price": 2.4065,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "i3.16xlarge",
+    "price": 2.4078,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "g3.8xlarge",
+    "price": 2.42,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "i2.8xlarge",
+    "price": 2.4306,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "d2.8xlarge",
+    "price": 2.437,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "i2.8xlarge",
+    "price": 2.4533,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "i3.8xlarge",
+    "price": 2.4725,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "p3.2xlarge",
+    "price": 2.5101,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "i2.8xlarge",
+    "price": 2.5198,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "x1.16xlarge",
+    "price": 2.5209,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "g2.8xlarge",
+    "price": 2.5382,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "x1.16xlarge",
+    "price": 2.5644,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "c3.xlarge",
+    "price": 2.58,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "p2.8xlarge",
+    "price": 2.6332,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "i2.4xlarge",
+    "price": 2.655,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "r3.8xlarge",
+    "price": 2.66,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "r3.8xlarge",
+    "price": 2.66,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "i3.16xlarge",
+    "price": 2.6856,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "p2.8xlarge",
+    "price": 2.7058,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "x1.16xlarge",
+    "price": 2.7272,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "p2.8xlarge",
+    "price": 2.7316,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "p2.8xlarge",
+    "price": 2.7361,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "p3.2xlarge",
+    "price": 2.743,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "i3.8xlarge",
+    "price": 2.752,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "g3.16xlarge",
+    "price": 2.779,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "p2.8xlarge",
+    "price": 2.7907,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "p2.8xlarge",
+    "price": 2.8005,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "g2.8xlarge",
+    "price": 2.808,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "g3.16xlarge",
+    "price": 2.8146,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "g3.8xlarge",
+    "price": 2.85,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "g3.8xlarge",
+    "price": 2.85,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "p2.8xlarge",
+    "price": 2.8612,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "i2.8xlarge",
+    "price": 2.8617,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "x1.16xlarge",
+    "price": 2.8632,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "p2.8xlarge",
+    "price": 2.9321,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "r4.16xlarge",
+    "price": 3.0106,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "c5.18xlarge",
+    "price": 3.06,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "g3.8xlarge",
+    "price": 3.068,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "g2.8xlarge",
+    "price": 3.088,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "x1.16xlarge",
+    "price": 3.1227,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "x1.16xlarge",
+    "price": 3.1328,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "i2.8xlarge",
+    "price": 3.1582,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "d2.4xlarge",
+    "price": 3.176,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "r3.8xlarge",
+    "price": 3.201,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "x1.16xlarge",
+    "price": 3.3944,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "p2.8xlarge",
+    "price": 3.4835,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "cr1.8xlarge",
+    "price": 3.5,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "cr1.8xlarge",
+    "price": 3.5,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "x1.16xlarge",
+    "price": 3.6147,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "x1.16xlarge",
+    "price": 3.6183,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "i2.8xlarge",
+    "price": 3.8801,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "p3.8xlarge",
+    "price": 3.9212,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "x1.32xlarge",
+    "price": 4.0014,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "x1.32xlarge",
+    "price": 4.0014,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "x1.32xlarge",
+    "price": 4.0014,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "x1.32xlarge",
+    "price": 4.0014,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "x1.16xlarge",
+    "price": 4.0211,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "i2.4xlarge",
+    "price": 4.051,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "ca-central-1a",
+    "instanceType": "x1.32xlarge",
+    "price": 4.0628,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "ca-central-1b",
+    "instanceType": "x1.32xlarge",
+    "price": 4.4016,
+    "type": "spot",
+    "region": "ca-central-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "p2.16xlarge",
+    "price": 4.4566,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "g3.16xlarge",
+    "price": 4.56,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "g3.16xlarge",
+    "price": 4.56,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "m5.24xlarge",
+    "price": 4.608,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "r4.16xlarge",
+    "price": 4.742,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "x1e.8xlarge",
+    "price": 4.8102,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "g3.16xlarge",
+    "price": 4.84,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "g3.16xlarge",
+    "price": 4.84,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "g3.16xlarge",
+    "price": 4.84,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "x1e.8xlarge",
+    "price": 4.8608,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "x1e.8xlarge",
+    "price": 4.869,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "p2.8xlarge",
+    "price": 4.9551,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "p3.8xlarge",
+    "price": 4.9648,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "p2.8xlarge",
+    "price": 4.98,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "i3.16xlarge",
+    "price": 4.992,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "i3.16xlarge",
+    "price": 4.992,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-2a",
+    "instanceType": "x1.32xlarge",
+    "price": 5.0418,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "x1.32xlarge",
+    "price": 5.0418,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "x1.32xlarge",
+    "price": 5.137,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "c3.2xlarge",
+    "price": 5.16,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "x1e.8xlarge",
+    "price": 5.2587,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "p2.16xlarge",
+    "price": 5.2791,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "x1e.8xlarge",
+    "price": 5.2978,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "f1.16xlarge",
+    "price": 5.3561,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1e",
+    "instanceType": "i2.8xlarge",
+    "price": 5.4864,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "i3.16xlarge",
+    "price": 5.504,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1c",
+    "instanceType": "i3.16xlarge",
+    "price": 5.504,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "i3.16xlarge",
+    "price": 5.504,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "us-east-2c",
+    "instanceType": "p2.16xlarge",
+    "price": 5.5153,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "x1.32xlarge",
+    "price": 5.6022,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "x1.32xlarge",
+    "price": 5.6022,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "p3.8xlarge",
+    "price": 5.6702,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "g3.16xlarge",
+    "price": 5.7,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "g3.16xlarge",
+    "price": 5.7,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "x1.16xlarge",
+    "price": 5.7183,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-2b",
+    "instanceType": "i3.16xlarge",
+    "price": 5.792,
+    "type": "spot",
+    "region": "eu-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "p2.16xlarge",
+    "price": 5.9721,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "x1.32xlarge",
+    "price": 6.0859,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-1b",
+    "instanceType": "g3.16xlarge",
+    "price": 6.136,
+    "type": "spot",
+    "region": "us-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "x1.32xlarge",
+    "price": 6.2281,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "p3.8xlarge",
+    "price": 6.2577,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "p3.8xlarge",
+    "price": 6.3374,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "d2.8xlarge",
+    "price": 6.352,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "p2.16xlarge",
+    "price": 6.493,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "x1e.8xlarge",
+    "price": 6.672,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "x1e.8xlarge",
+    "price": 6.672,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "p2.16xlarge",
+    "price": 6.8042,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "p2.8xlarge",
+    "price": 7.2,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "p2.8xlarge",
+    "price": 7.2,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "x1.32xlarge",
+    "price": 7.2752,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "p2.16xlarge",
+    "price": 7.288,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "p3.8xlarge",
+    "price": 7.4078,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "p3.8xlarge",
+    "price": 7.505,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "p2.8xlarge",
+    "price": 7.776,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "f1.16xlarge",
+    "price": 7.9052,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "i2.8xlarge",
+    "price": 8.102,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "p3.8xlarge",
+    "price": 8.1939,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "x1e.16xlarge",
+    "price": 8.7752,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "x1e.16xlarge",
+    "price": 8.7978,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "p3.8xlarge",
+    "price": 9.7615,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1f",
+    "instanceType": "p3.16xlarge",
+    "price": 9.881,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "p2.16xlarge",
+    "price": 10.1476,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1c",
+    "instanceType": "c3.4xlarge",
+    "price": 10.32,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "x1e.16xlarge",
+    "price": 10.5222,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "x1e.16xlarge",
+    "price": 10.5928,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "p2.8xlarge",
+    "price": 10.608,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "p2.8xlarge",
+    "price": 10.608,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "x1.32xlarge",
+    "price": 10.8702,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "p3.16xlarge",
+    "price": 11.5136,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "f1.16xlarge",
+    "price": 13.2,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "f1.16xlarge",
+    "price": 13.2,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "f1.16xlarge",
+    "price": 13.2,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "x1.32xlarge",
+    "price": 13.338,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "p2.16xlarge",
+    "price": 13.9809,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "p2.16xlarge",
+    "price": 14.0255,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "p2.16xlarge",
+    "price": 14.4,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "p2.16xlarge",
+    "price": 14.4,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "f1.16xlarge",
+    "price": 14.52,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "f1.16xlarge",
+    "price": 14.52,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "f1.16xlarge",
+    "price": 14.52,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-2a",
+    "instanceType": "p3.16xlarge",
+    "price": 14.7688,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-east-2b",
+    "instanceType": "p3.16xlarge",
+    "price": 14.9962,
+    "type": "spot",
+    "region": "us-east-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "p3.16xlarge",
+    "price": 15.0169,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "x1.32xlarge",
+    "price": 16.006,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-central-1a",
+    "instanceType": "p2.16xlarge",
+    "price": 21.216,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-central-1b",
+    "instanceType": "p2.16xlarge",
+    "price": 21.216,
+    "type": "spot",
+    "region": "eu-central-1"
+  },
+  {
+    "zone": "eu-west-1c",
+    "instanceType": "cg1.4xlarge",
+    "price": 23.6,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "cg1.4xlarge",
+    "price": 23.6,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "p3.16xlarge",
+    "price": 24.48,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1b",
+    "instanceType": "p3.16xlarge",
+    "price": 24.48,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "p3.16xlarge",
+    "price": 26.44,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "p3.16xlarge",
+    "price": 26.44,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-east-1d",
+    "instanceType": "x1e.32xlarge",
+    "price": 26.688,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "x1e.32xlarge",
+    "price": 26.688,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-east-1a",
+    "instanceType": "x1e.32xlarge",
+    "price": 26.688,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-east-1c",
+    "instanceType": "x1e.32xlarge",
+    "price": 26.688,
+    "type": "spot",
+    "region": "us-east-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "x1e.32xlarge",
+    "price": 26.688,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2c",
+    "instanceType": "hi1.4xlarge",
+    "price": 31,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "us-west-2b",
+    "instanceType": "hi1.4xlarge",
+    "price": 31,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "hi1.4xlarge",
+    "price": 31,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "hi1.4xlarge",
+    "price": 31,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "us-west-2a",
+    "instanceType": "hi1.4xlarge",
+    "price": 31,
+    "type": "spot",
+    "region": "us-west-2"
+  },
+  {
+    "zone": "eu-west-1b",
+    "instanceType": "x1e.32xlarge",
+    "price": 32,
+    "type": "spot",
+    "region": "eu-west-1"
+  },
+  {
+    "zone": "eu-west-1a",
+    "instanceType": "x1e.32xlarge",
+    "price": 32,
+    "type": "spot",
+    "region": "eu-west-1"
+  }
+]


### PR DESCRIPTION
aws-provisioner has a duplicated logic from ec2-manager to retrive spot
prices from Amazon. We remove this duplicated code and get the prices
through ec2-manager service.