### PR TITLE
Bug 1431750 - add additionalProperties to schemas where missing

### DIFF
--- a/schemas/create-worker-type-request.yml
+++ b/schemas/create-worker-type-request.yml
@@ -149,6 +149,7 @@ properties:
             - eu-central-1
         launchSpec:
           type: object
+          additionalProperties: true
           description: |
             LaunchSpecification entries unique to this Region
           properties:

--- a/schemas/get-secret-response.yml
+++ b/schemas/get-secret-response.yml
@@ -3,6 +3,7 @@ title:                      "Get Secret Response"
 description: |
   Secrets from the provisioner
 type:                       object
+additionalProperties:       false
 properties:
   data:
     type: object
@@ -10,6 +11,7 @@ properties:
       Free-form object which contains secrets from the worker type definition
   credentials:
     type: object
+    additionalProperties:   false
     description: |
       Generated Temporary credentials from the Provisioner
     properties:

--- a/schemas/get-worker-type-response.yml
+++ b/schemas/get-worker-type-response.yml
@@ -154,6 +154,7 @@ properties:
             The Amazon AWS Region being configured.  Example: us-west-1
         launchSpec:
           type: object
+          additionalProperties: true
           description: |
             LaunchSpecification entries unique to this Region
           properties:


### PR DESCRIPTION
Hi John,

The motivation for this PR is that we are always explicit about `additionalProperties` - which has the side effect that sometimes it is kind of obvious that it is `true` but we set it anyway. This change is a forerunner to making a separate change to making `additionalProperties` a mandatory field when `type: object` is specified. This change therefore makes everything conformant before we add the extra rigor.

Let me know what you think! 😄 