### PR TITLE
Fix staging url so staging workers can self-configure

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -122,7 +122,7 @@ staging:
     project: 'staging-aws'
     mock: false
   server:
-    publicUrl: https://staging-aws-provisioner.herokuapp.com
+    publicUrl: https://provisioner-staging.herokuapp.com
     port: !env:number PORT
     env: development
     forceSSL: true


### PR DESCRIPTION
This was causing staging workers to query incorrect url to collect their secrets.