### PR TITLE
Work with a single universal SSH KeyPair

### DIFF
--- a/src/aws-manager.js
+++ b/src/aws-manager.js
@@ -413,27 +413,6 @@ class AwsManager {
   }
 
   /**
-   * wrapper for brevity
-   */
-  createPubKeyHash() {
-    return keyPairs.createPubKeyHash(this.pubKey);
-  }
-
-  /**
-   * wrapper for brevity
-   */
-  createKeyPairName(workerName) {
-    return keyPairs.createKeyPairName(this.keyPrefix, this.pubKey, workerName);
-  }
-
-  /**
-   * wrapper for brevity
-   */
-  parseKeyPairName(name) {
-    return keyPairs.parseKeyPairName(name);
-  }
-
-  /**
    * Kill spot requests to change negatively by a capacity unit change.  We use
    * this function to do things like canceling spot requests that exceed the
    * number we require.

--- a/src/key-pairs.js
+++ b/src/key-pairs.js
@@ -20,7 +20,7 @@ module.exports.createPubKeyHash = function(pubKey) {
 /**
  * Create a KeyPair name
  */
-module.exports.createKeyPairName = function(prefix, pubKey, workerName) {
+module.exports.createKeyPairName = function(prefix, pubKey) {
   assert(prefix);
   // We want to support the case where we're still using a config setting
   // that ends in : as it used to
@@ -29,29 +29,6 @@ module.exports.createKeyPairName = function(prefix, pubKey, workerName) {
   }
   assert(prefix.indexOf(':') === -1, 'only up to one trailing colon allowed');
   assert(pubKey);
-  assert(workerName);
-  return prefix + ':' + workerName + ':' + module.exports.createPubKeyHash(pubKey);
+  return prefix + ':' + module.exports.createPubKeyHash(pubKey);
 };
 
-/**
- * Parse a KeyPair name into an object with a prefix, workerType and
- * keyHash properties on the returned object
- */
-module.exports.parseKeyPairName = function(name) {
-  assert(name);
-  let parts = name.split(':');
-  let rv = {
-    prefix: parts[0],
-    workerType: parts[1],
-  };
-
-  if (parts.length == 2) {
-    rv.keyHash = '';
-  } else if (parts.length === 3) {
-    rv.keyHash = parts[2];
-  } else {
-    throw new Error('KeyPair name is not parseable: ' + name);
-
-  }
-  return rv;
-};

--- a/src/main.js
+++ b/src/main.js
@@ -281,6 +281,7 @@ let load = loader({
       monitor,
       queue,
     }) => {
+      console.log('SSH-Key: ' + cfg.app.awsInstancePubkey);
       let provisioner = new provision.Provisioner({
         WorkerType: WorkerType,
         Secret: Secret,
@@ -290,6 +291,8 @@ let load = loader({
         awsManager: awsManager,
         ec2manager: ec2manager,
         monitor: monitor,
+        keyPrefix: cfg.app.awsKeyPrefix,
+        instancePubKey: cfg.app.awsInstancePubkey,
       });
 
       let i = new Iterate({


### PR DESCRIPTION
This is the patch corresponding to https://github.com/taskcluster/ec2-manager/pull/56 which.  As in the commit message, this patch will create a single provisioner-wide ssh key pair which will be used for all worker types.  This is functionally equivalent to what we are currently doing, just that we're no longer limited to 5000 worker types

This is functionally equivalent to what we used to do, except that
instead of creating 1 key pair for every worker type, we're creating
one key pair for every provisioner instance.  This is the same security
that we had before, just expressed a little differently.