### PR TITLE
Use new scope expressions in API entries and upgrade taskcluster-lib-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "slugid": "^1.1.0",
     "source-map-support": "^0.4.14",
     "taskcluster-client": "^2.5.4",
-    "taskcluster-lib-api": "^3.2.2",
+    "taskcluster-lib-api": "^8.3.0",
     "taskcluster-lib-app": "^1.0.0",
     "taskcluster-lib-docs": "^3.3.1",
     "taskcluster-lib-iterate": "^1.0.2",

--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -139,7 +139,6 @@ api.declare({
   method: 'put',
   route: '/worker-type/:workerType',
   name: 'createWorkerType',
-  deferAuth: true,
   scopes: 'aws-provisioner:manage-worker-type:<workerType>',
   input: 'create-worker-type-request.json#',
   output: 'get-worker-type-response.json#',
@@ -181,9 +180,7 @@ api.declare({
   input.lastModified = new Date();
 
   // Authenticate request with parameterized scope
-  if (!req.satisfies({workerType: workerType})) {
-    return;
-  }
+  await req.authorize({workerType: workerType});
 
   let workerForValidation = _.defaults({}, {workerType: workerType}, input);
 
@@ -261,7 +258,6 @@ api.declare({
   method: 'post',
   route: '/worker-type/:workerType/update',
   name: 'updateWorkerType',
-  deferAuth: true,
   scopes: 'aws-provisioner:manage-worker-type:<workerType>',
   input: 'create-worker-type-request.json#',
   output: 'get-worker-type-response.json#',
@@ -292,7 +288,7 @@ api.declare({
 
   input.lastModified = modDate;
 
-  if (!req.satisfies({workerType: workerType})) { return undefined; }
+  await req.authorize({workerType: workerType});
 
   let workerForValidation = _.defaults({}, {workerType: workerType}, input);
 
@@ -370,7 +366,6 @@ api.declare({
   method: 'get',
   route: '/worker-type/:workerType',
   name: 'workerType',
-  deferAuth: true,
   scopes: {AnyOf: [
     'aws-provisioner:view-worker-type:<workerType>',
     'aws-provisioner:manage-worker-type:<workerType>',
@@ -389,7 +384,7 @@ api.declare({
 }, async function(req, res) {
   let workerType = req.params.workerType;
 
-  if (!req.satisfies({workerType: workerType})) { return undefined; }
+  await req.authorize({workerType: workerType});
 
   let worker;
   try {
@@ -418,7 +413,6 @@ api.declare({
   method: 'delete',
   route: '/worker-type/:workerType',
   name: 'removeWorkerType',
-  deferAuth: true,
   scopes: 'aws-provisioner:manage-worker-type:<workerType>',
   input: undefined,  // No input
   output: undefined,  // No output
@@ -440,7 +434,7 @@ api.declare({
   let that = this;
   let workerType = req.params.workerType;
 
-  if (!req.satisfies({workerType: workerType})) { return undefined; }
+  await req.authorize({workerType: workerType});
 
   try {
     await this.WorkerType.remove({workerType: workerType}, true);
@@ -497,7 +491,7 @@ api.declare({
   let input = req.body;
   let token = req.params.token;
 
-  if (!req.satisfies({workerType: input.workerType})) { return undefined; }
+  await req.authorize({workerType: workerType});
 
   let secret;
   try {
@@ -654,7 +648,6 @@ api.declare({
   method: 'get',
   route: '/worker-type/:workerType/launch-specifications',
   name: 'getLaunchSpecs',
-  deferAuth: true,
   scopes: {AnyOf: [
     'aws-provisioner:view-worker-type:<workerType>',
     'aws-provisioner:manage-worker-type:<workerType>',
@@ -673,7 +666,7 @@ api.declare({
 }, async function(req, res) {
   let workerType = req.params.workerType;
 
-  if (!req.satisfies({workerType: workerType})) { return undefined; }
+  await req.authorize({workerType: workerType});
 
   let worker = await this.WorkerType.load({workerType: workerType});
   let outcome;
@@ -697,7 +690,6 @@ api.declare({
   route: '/state/:workerType',
   name: 'state',
   title: 'Get AWS State for a worker type',
-  deferAuth: true,
   stability:  API.stability.stable,
   description: [
     'Return the state of a given workertype as stored by the provisioner. ',

--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -22,6 +22,7 @@ let EC2_INSTANCE_ID_PATTERN = /^i-[a-fA-F0-9]{8}$/;
  */
 let api = new API({
   title: 'AWS Provisioner API Documentation',
+  name: 'awsprovisioner',
   description: [
     'The AWS Provisioner is responsible for provisioning instances on EC2 for use in',
     'Taskcluster.  The provisioner maintains a set of worker configurations which',
@@ -139,7 +140,7 @@ api.declare({
   route: '/worker-type/:workerType',
   name: 'createWorkerType',
   deferAuth: true,
-  scopes: [['aws-provisioner:manage-worker-type:<workerType>']],
+  scopes: 'aws-provisioner:manage-worker-type:<workerType>',
   input: 'create-worker-type-request.json#',
   output: 'get-worker-type-response.json#',
   title: 'Create new Worker Type',
@@ -261,7 +262,7 @@ api.declare({
   route: '/worker-type/:workerType/update',
   name: 'updateWorkerType',
   deferAuth: true,
-  scopes: [['aws-provisioner:manage-worker-type:<workerType>']],
+  scopes: 'aws-provisioner:manage-worker-type:<workerType>',
   input: 'create-worker-type-request.json#',
   output: 'get-worker-type-response.json#',
   title: 'Update Worker Type',
@@ -370,10 +371,10 @@ api.declare({
   route: '/worker-type/:workerType',
   name: 'workerType',
   deferAuth: true,
-  scopes: [
-    ['aws-provisioner:view-worker-type:<workerType>'],
-    ['aws-provisioner:manage-worker-type:<workerType>'],
-  ],
+  scopes: {AnyOf: [
+    'aws-provisioner:view-worker-type:<workerType>',
+    'aws-provisioner:manage-worker-type:<workerType>',
+  ]},
   input: undefined,  // No input
   output: 'get-worker-type-response.json#',
   title: 'Get Worker Type',
@@ -418,7 +419,7 @@ api.declare({
   route: '/worker-type/:workerType',
   name: 'removeWorkerType',
   deferAuth: true,
-  scopes: [['aws-provisioner:manage-worker-type:<workerType>']],
+  scopes: 'aws-provisioner:manage-worker-type:<workerType>',
   input: undefined,  // No input
   output: undefined,  // No output
   title: 'Delete Worker Type',
@@ -480,7 +481,7 @@ api.declare({
   method: 'put',
   route: '/secret/:token',
   name: 'createSecret',
-  scopes: [['aws-provisioner:create-secret:<workerType>']],
+  scopes: 'aws-provisioner:create-secret:<workerType>',
   input: 'create-secret-request.json#',
   title: 'Create new Secret',
   stability:  API.stability.stable,
@@ -654,10 +655,10 @@ api.declare({
   route: '/worker-type/:workerType/launch-specifications',
   name: 'getLaunchSpecs',
   deferAuth: true,
-  scopes: [
-    ['aws-provisioner:view-worker-type:<workerType>'],
-    ['aws-provisioner:manage-worker-type:<workerType>'],
-  ],
+  scopes: {AnyOf: [
+    'aws-provisioner:view-worker-type:<workerType>',
+    'aws-provisioner:manage-worker-type:<workerType>',
+  ]},
   input: undefined,  // No input
   output: 'get-launch-specs-response.json#',
   title: 'Get All Launch Specifications for WorkerType',


### PR DESCRIPTION
This PR is created with the intention of fixing [these schema validation failures](https://travis-ci.org/taskcluster/taskcluster-client-go/builds/371586235#L560-L586).

We don't version api-reference.json and exchanges-reference.json, which means that currently aws provisioner reference fails schema validation.

I've made an initial stab at fixing the schema validation issues, but it looks like there are other changes in taskcluster-lib-api that need addressing, e.g.

```
> yarn run lint && yarn run unittest

yarn run v0.27.5
$ eslint src/*.js test-src/*.js
Done in 1.84s.
yarn run v0.27.5
$ NODE_ENV=test mocha test/*_test.js

/Users/pmoore/git/aws-provisioner/node_modules/taskcluster-lib-api/src/api.js:779
  assert(!options.deferAuth,
  ^
AssertionError [ERR_ASSERTION]: deferAuth is deprecated! https://github.com/taskcluster/taskcluster-lib-api#request-handlers
    at API.declare (/Users/pmoore/git/aws-provisioner/node_modules/taskcluster-lib-api/src/api.js:779:3)
    at Object.<anonymous> (/Users/pmoore/git/aws-provisioner/src/api-v1.js:138:5)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/pmoore/git/aws-provisioner/lib/main.js:45:10)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Suite.<anonymous> (/Users/pmoore/git/aws-provisioner/test-src/badworkertype_test.js:3:14)
    at Object.create (/Users/pmoore/git/aws-provisioner/node_modules/mocha/lib/interfaces/common.js:114:19)
    at context.suite (/Users/pmoore/git/aws-provisioner/node_modules/mocha/lib/interfaces/tdd.js:51:27)
    at Object.<anonymous> (/Users/pmoore/git/aws-provisioner/test-src/badworkertype_test.js:2:1)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at /Users/pmoore/git/aws-provisioner/node_modules/mocha/lib/mocha.js:231:27
    at Array.forEach (native)
    at Mocha.loadFiles (/Users/pmoore/git/aws-provisioner/node_modules/mocha/lib/mocha.js:228:14)
    at Mocha.run (/Users/pmoore/git/aws-provisioner/node_modules/mocha/lib/mocha.js:514:10)
    at Object.<anonymous> (/Users/pmoore/git/aws-provisioner/node_modules/mocha/bin/_mocha:480:18)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Function.Module.runMain (module.js:605:10)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:575:3
error Command failed with exit code 1.
```

I'm not sure I'll be able to fix those issues, but I at least wanted to start the process by upgrading the api reference file, and maybe others can push to this branch to help fix the remaining issues.

Another option we have is to version our api reference schema, so AWS Provisioner can point to the old version. Although maybe long term it is better if it keeps up-to-date, I can't really judge.

Thanks!