### PR TITLE
Moved common schema elements into shared schemas

### DIFF
--- a/schemas/availability-zone-configuration.yml
+++ b/schemas/availability-zone-configuration.yml
@@ -1,0 +1,32 @@
+$schema: http://json-schema.org/draft-06/schema#
+title: Availability Zone Configuration
+type: object
+description: Availability zone configuration
+properties:
+  availabilityZone:
+    type: string
+    description: |
+      The AWS availability zone being configured.  Example: eu-central-1b
+  region:
+    type: string
+    description: |
+      The AWS region containing this availability zone.  Example: eu-central-1
+  launchSpec:
+    type: object
+    description: |
+      LaunchSpecification entries unique to this AZ
+  secrets:
+    type: object
+    description: |
+      Static Secrets unique to this AZ
+    default: {}
+  userData:
+    type: object
+    description: |
+      UserData entries unique to this AZ
+    default: {}
+additionalProperties: false
+required:
+  - region
+  - availabilityZone
+  - launchSpec

--- a/schemas/backend-status-response.yml
+++ b/schemas/backend-status-response.yml
@@ -1,5 +1,5 @@
-$schema:  http://json-schema.org/draft-04/schema#
-title:                      "Backend Status Response"
+$schema: http://json-schema.org/draft-06/schema#
+title: "Backend Status Response"
 description: |
   Backend Status Response
 type:                       object

--- a/schemas/create-secret-request.yml
+++ b/schemas/create-secret-request.yml
@@ -1,5 +1,5 @@
-$schema:  http://json-schema.org/draft-04/schema#
-title:                      "Get Secret Request"
+$schema: http://json-schema.org/draft-06/schema#
+title: "Secret Request"
 description: |
   A Secret
 type:                       object

--- a/schemas/create-worker-type-request.yml
+++ b/schemas/create-worker-type-request.yml
@@ -1,5 +1,5 @@
-$schema:  http://json-schema.org/draft-04/schema#
-title:                      "Create Worker Type Request"
+$schema: http://json-schema.org/draft-06/schema#
+title: "Create Worker Type Request"
 description: |
   A worker launchSpecification and required metadata
 type:                       object
@@ -81,139 +81,13 @@ properties:
       as all instances are Spot
   instanceTypes:
     type: array
-    items:
-      type: object
-      description: Instance Type configuration
-      properties:
-        instanceType:
-          description: |
-            InstanceType name for Amazon.
-          type: string
-        capacity:
-          description: |
-            This number represents the number of tasks that this instance type
-            is capable of running concurrently.  This is used by the provisioner
-            to know how many pending tasks to offset a pending instance of this
-            type by
-          type: number
-        utility:
-          description: |
-            This number is a relative measure of performance between two instance
-            types.  It is multiplied by the spot price from Amazon to figure out
-            which instance type is the cheapest one
-          type: number
-        launchSpec:
-          type: object
-          description: |
-            LaunchSpecification entries unique to this InstanceType
-        secrets:
-          type: object
-          description: |
-            Static Secrets unique to this InstanceType
-        userData:
-          type: object
-          description: |
-            UserData entries unique to this InstanceType
-        scopes:
-          type: array
-          items:
-            type: string
-            pattern: "^[\x20-\x7e]*$"
-          description: |
-            Scopes which should be included for this InstanceType.  Scopes must
-            be composed of printable ASCII characters and spaces.
-      required:
-        - instanceType
-        - capacity
-        - utility
-        - launchSpec
-        - secrets
-        - userData
-        - scopes
-      additionalProperties: false
+    items: {$ref: "https://schemas.taskcluster.net/aws-provisioner/v1/instance-type-configuration.json#"}
   regions:
     type: array
-    items:
-      type: object
-      description: Region configuration
-      properties:
-        region:
-          type: string
-          description: |
-            The Amazon AWS Region being configured.  Example: us-west-1
-          enum:
-            - us-west-2
-            - us-east-1
-            - us-east-2
-            - us-west-1
-            - eu-central-1
-        launchSpec:
-          type: object
-          additionalProperties: true
-          description: |
-            LaunchSpecification entries unique to this Region
-          properties:
-            ImageId:
-              type: string
-              description: Per-region AMI ImageId
-          required:
-            - ImageId
-        secrets:
-          type: object
-          description: |
-            Static Secrets unique to this Region
-        userData:
-          type: object
-          description: |
-            UserData entries unique to this Region
-        scopes:
-          type: array
-          items:
-            type: string
-            pattern: "^[\x20-\x7e]*$"
-          description: |
-            Scopes which should be included for this Region.  Scopes must be
-            composed of printable ASCII characters and spaces.
-      additionalProperties: false
-      required:
-        - region
-        - launchSpec
-        - secrets
-        - userData
-        - scopes
+    items: {$ref: "https://schemas.taskcluster.net/aws-provisioner/v1/region-configuration.json#"}
   availabilityZones:
     type: array
-    items:
-      type: object
-      description: Availability zone configuration
-      properties:
-        availabilityZone:
-          type: string
-          description: |
-            The AWS availability zone being configured.  Example: eu-central-1b
-        region:
-          type: string
-          description: |
-            The AWS region containing this availability zone.  Example: eu-central-1
-        launchSpec:
-          type: object
-          description: |
-            LaunchSpecification entries unique to this AZ
-        secrets:
-          type: object
-          description: |
-            Static Secrets unique to this AZ
-          default: {}
-        userData:
-          type: object
-          description: |
-            UserData entries unique to this AZ
-          default: {}
-      additionalProperties: false
-      required:
-        - region
-        - availabilityZone
-        - launchSpec
+    items: {$ref: "http://schemas.taskcluster.net/aws-provisioner/v1/availability-zone-configuration.json#"}
 additionalProperties: false
 required:
   - launchSpec

--- a/schemas/get-launch-specs-response.yml
+++ b/schemas/get-launch-specs-response.yml
@@ -1,5 +1,5 @@
-$schema:  http://json-schema.org/draft-04/schema#
-title:                      "Get All Launch Specs Response"
+$schema: http://json-schema.org/draft-06/schema#
+title: "Launch Specs Response"
 description: |
   All of the launch specifications for a worker type
 type:                       object

--- a/schemas/get-secret-response.yml
+++ b/schemas/get-secret-response.yml
@@ -1,5 +1,5 @@
-$schema:  http://json-schema.org/draft-04/schema#
-title:                      "Get Secret Response"
+$schema: http://json-schema.org/draft-06/schema#
+title: "Secret Response"
 description: |
   Secrets from the provisioner
 type:                       object

--- a/schemas/get-worker-type-last-modified.yml
+++ b/schemas/get-worker-type-last-modified.yml
@@ -1,7 +1,7 @@
-$schema:  http://json-schema.org/draft-04/schema#
-title:                      "Get Worker Type Response"
+$schema: http://json-schema.org/draft-06/schema#
+title: "Worker Type Last Modified"
 description: |
-  Get the last modified date of a workerType
+  The last modified date of a workerType
 type:                       object
 properties:
   workerType:

--- a/schemas/get-worker-type-response.yml
+++ b/schemas/get-worker-type-response.yml
@@ -1,5 +1,5 @@
-$schema:  http://json-schema.org/draft-04/schema#
-title:                      "Get Worker Type Response"
+$schema: http://json-schema.org/draft-06/schema#
+title: "Worker Type Response"
 description: |
   A worker launchSpecification and required metadata
 type:                       object
@@ -92,133 +92,13 @@ properties:
       when this worker type definition was last altered (inclusive of creation)
   instanceTypes:
     type: array
-    items:
-      type: object
-      description: Instance Type configuration
-      properties:
-        instanceType:
-          description: |
-            InstanceType name for Amazon.
-          type: string
-        capacity:
-          description: |
-            This number represents the number of tasks that this instance type
-            is capable of running concurrently.  This is used by the provisioner
-            to know how many pending tasks to offset a pending instance of this
-            type by
-          type: number
-        utility:
-          description: |
-            This number is a relative measure of performance between two instance
-            types.  It is multiplied by the spot price from Amazon to figure out
-            which instance type is the cheapest one
-          type: number
-        launchSpec:
-          type: object
-          description: |
-            LaunchSpecification entries unique to this InstanceType
-        secrets:
-          type: object
-          description: |
-            Static Secrets unique to this InstanceType
-        userData:
-          type: object
-          description: |
-            UserData entries unique to this InstanceType
-        scopes:
-          type: array
-          items:
-            type: string
-            pattern: "^[\x20-\x7e]*$"
-          description: |
-            Scopes which should be included for this InstanceType.  Scopes must
-            be composed of printable ASCII characters and spaces.
-      required:
-        - instanceType
-        - capacity
-        - utility
-        - launchSpec
-        - secrets
-        - userData
-        - scopes
-      additionalProperties: false
+    items: {$ref: "https://schemas.taskcluster.net/aws-provisioner/v1/instance-type-configuration.json#"}
   regions:
     type: array
-    items:
-      type: object
-      description: Region configuration
-      properties:
-        region:
-          type: string
-          description: |
-            The Amazon AWS Region being configured.  Example: us-west-1
-        launchSpec:
-          type: object
-          additionalProperties: true
-          description: |
-            LaunchSpecification entries unique to this Region
-          properties:
-            ImageId:
-              type: string
-              description: Per-region AMI ImageId
-          required:
-            - ImageId
-        secrets:
-          type: object
-          description: |
-            Static Secrets unique to this Region
-        userData:
-          type: object
-          description: |
-            UserData entries unique to this Region
-        scopes:
-          type: array
-          items:
-            type: string
-            pattern: "^[\x20-\x7e]*$"
-          description: |
-            Scopes which should be included for this Region.  Scopes must be
-            composed of printable ASCII characters and spaces.
-      additionalProperties: false
-      required:
-        - region
-        - launchSpec
-        - secrets
-        - userData
-        - scopes
+    items: {$ref: "https://schemas.taskcluster.net/aws-provisioner/v1/region-configuration.json#"}
   availabilityZones:
     type: array
-    items:
-      type: object
-      description: Availability zone configuration
-      properties:
-        availabilityZone:
-          type: string
-          description: |
-            The AWS availability zone being configured.  Example: eu-central-1b
-        region:
-          type: string
-          description: |
-            The AWS region containing this availability zone.  Example: eu-central-1
-        launchSpec:
-          type: object
-          description: |
-            LaunchSpecification entries unique to this AZ
-        secrets:
-          type: object
-          description: |
-            Static Secrets unique to this AZ
-          default: {}
-        userData:
-          type: object
-          description: |
-            UserData entries unique to this AZ
-          default: {}
-      additionalProperties: false
-      required:
-        - availabilityZone
-        - region
-        - launchSpec
+    items: {$ref: "http://schemas.taskcluster.net/aws-provisioner/v1/availability-zone-configuration.json#"}
 additionalProperties: false
 required:
   - workerType

--- a/schemas/instance-type-configuration.yml
+++ b/schemas/instance-type-configuration.yml
@@ -1,0 +1,50 @@
+$schema: http://json-schema.org/draft-06/schema#
+type: object
+description: Instance Type configuration
+properties:
+  instanceType:
+    description: |
+      InstanceType name for Amazon.
+    type: string
+  capacity:
+    description: |
+      This number represents the number of tasks that this instance type
+      is capable of running concurrently.  This is used by the provisioner
+      to know how many pending tasks to offset a pending instance of this
+      type by
+    type: number
+  utility:
+    description: |
+      This number is a relative measure of performance between two instance
+      types.  It is multiplied by the spot price from Amazon to figure out
+      which instance type is the cheapest one
+    type: number
+  launchSpec:
+    type: object
+    description: |
+      LaunchSpecification entries unique to this InstanceType
+  secrets:
+    type: object
+    description: |
+      Static Secrets unique to this InstanceType
+  userData:
+    type: object
+    description: |
+      UserData entries unique to this InstanceType
+  scopes:
+    type: array
+    items:
+      type: string
+      pattern: "^[\x20-\x7e]*$"
+    description: |
+      Scopes which should be included for this InstanceType.  Scopes must
+      be composed of printable ASCII characters and spaces.
+required:
+  - instanceType
+  - capacity
+  - utility
+  - launchSpec
+  - secrets
+  - userData
+  - scopes
+additionalProperties: false

--- a/schemas/list-worker-types-response.yml
+++ b/schemas/list-worker-types-response.yml
@@ -1,6 +1,6 @@
----
-  title: "List Worker Types"
-  type: "array"
-  items: 
-    type: "string"
-  uniqueItems: true
+$schema: http://json-schema.org/draft-06/schema#
+title: "List Worker Types"
+type: "array"
+items: 
+  type: "string"
+uniqueItems: true

--- a/schemas/list-worker-types-summaries-response.yml
+++ b/schemas/list-worker-types-summaries-response.yml
@@ -1,5 +1,4 @@
----
-$schema:  http://json-schema.org/draft-04/schema#
+$schema: http://json-schema.org/draft-06/schema#
 title: "List Worker Type Summaries Response"
 type: array
 uniqueItems: true

--- a/schemas/region-configuration.xml
+++ b/schemas/region-configuration.xml
@@ -1,0 +1,39 @@
+$schema: http://json-schema.org/draft-06/schema#
+title: Region Configuration
+type: object
+description: Region configuration
+properties:
+  region:
+    type: string
+    description: |
+      The Amazon AWS Region being configured.  Example: us-west-1
+    enum:
+      - us-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - eu-central-1
+  launchSpec: {$ref: "https://schemas.taskcluster.net/aws-provisioner/v1/region-launch-spec.json#"}
+  secrets:
+    type: object
+    description: |
+      Static Secrets unique to this Region
+  userData:
+    type: object
+    description: |
+      UserData entries unique to this Region
+  scopes:
+    type: array
+    items:
+      type: string
+      pattern: "^[\x20-\x7e]*$"
+    description: |
+      Scopes which should be included for this Region.  Scopes must be
+      composed of printable ASCII characters and spaces.
+additionalProperties: false
+required:
+  - region
+  - launchSpec
+  - secrets
+  - userData
+  - scopes

--- a/schemas/region-launch-spec.yml
+++ b/schemas/region-launch-spec.yml
@@ -1,0 +1,12 @@
+$schema: http://json-schema.org/draft-06/schema#
+title: "Region Launch Spec"
+type: object
+additionalProperties: true
+description: |
+  LaunchSpecification entries unique to this Region
+properties:
+  ImageId:
+    type: string
+    description: Per-region AMI ImageId
+required:
+  - ImageId

--- a/schemas/worker-type-message.yml
+++ b/schemas/worker-type-message.yml
@@ -1,16 +1,15 @@
----
-  $schema: http://json-schema.org/draft-04/schema#
-  title: Worker Type Message
-  description: Message reporting that an action occured to a worker type
-  type: object
-  properties:
-    workerType:
-      description: |
-        Name of the worker type which was created
-      type: string
-    version:
-      type: number
-  additionalProperties: false
-  required:
-    - workerType
-    - version
+$schema: http://json-schema.org/draft-06/schema#
+title: Worker Type Message
+description: Message reporting that an action occured to a worker type
+type: object
+properties:
+  workerType:
+    description: |
+      Name of the worker type which was created
+    type: string
+  version:
+    type: number
+additionalProperties: false
+required:
+  - workerType
+  - version

--- a/schemas/worker-type-summary.yml
+++ b/schemas/worker-type-summary.yml
@@ -1,4 +1,4 @@
-$schema:  http://json-schema.org/draft-04/schema#
+$schema: http://json-schema.org/draft-06/schema#
 title: Worker Type Summary
 description: |
   A summary of a worker type's current state, expresed in terms of capacity.


### PR DESCRIPTION
This should reduce the amount of code duplication we currently have in generated taskcluster-client-go code. In [tcawsprovisioner package](https://godoc.org/github.com/taskcluster/taskcluster-client-go/tcawsprovisioner) we currently have:

```go
type GetWorkerTypeResponse
type GetWorkerTypeResponse1
type InstanceTypeConfiguration
type InstanceTypeConfiguration1
type LaunchSpec
type LaunchSpec1
type RegionConfiguration
type RegionConfiguration1
```

With this PR, we should reduce this to:

```go
type InstanceTypeConfiguration
type LaunchSpec
type RegionConfiguration
type WorkerTypeLastModified
type WorkerTypeResponse
```