### PR TITLE
Bug 1373938 - Submit worker type pending count data to statsum and/or ActiveData

### DIFF
--- a/lib/provision.js
+++ b/lib/provision.js
@@ -360,6 +360,8 @@ class Provisioner {
       change: change,
     }, 'changeForType outcome');
 
+    this.monitor.measure(`worker.${workerType.workerType}.pendingTasks`, pendingTasks);
+
     return change;
   }
 


### PR DESCRIPTION
Since we're already doing everything other than actually measuring it in the provisioner...