### PR TITLE
Bug 1486812 - block g2 instances in eu-central-1c

### DIFF
--- a/lib/worker-type.js
+++ b/lib/worker-type.js
@@ -33,6 +33,10 @@ function isAllowedCombo(zone, type, region) {
         return false;
       }
       break;
+    case 'g2':
+      if (zone === 'eu-central-1c') {
+        return false;
+      }
     default:
       return true;
   }


### PR DESCRIPTION
These instance types do not exist in eu-central-1c, so we shouldn't ask to create them there.  Sadly, AWS provides no API to determine these configurations.