### PR TITLE
Bug 1462768 - provide taskclusterRootUrl in userdata to workers

### DIFF
--- a/lib/worker-type.js
+++ b/lib/worker-type.js
@@ -605,19 +605,22 @@ WorkerType.createLaunchSpec = function(bid, worker, keyPrefix, provisionerId, pr
   let securityToken = slugid.v4();
 
   config.userData = {
-    data: config.userData,
+    availabilityZone: bid.zone,
     capacity: capacity,
-    workerType: worker.workerType,
+    data: config.userData,
+    instanceType: bid.type,
+    lastModified: worker.lastModified.toISOString(),
+    launchSpecGenerated: new Date().toISOString(),
+    price: bid.truePrice,
+    provisionerBaseUrl: provisionerBaseUrl,
     provisionerId: provisionerId,
     region: bid.region,
-    availabilityZone: bid.zone,
-    instanceType: bid.type,
-    spotBid: bid.price,
-    price: bid.truePrice,
-    launchSpecGenerated: new Date().toISOString(),
-    lastModified: worker.lastModified.toISOString(),
-    provisionerBaseUrl: provisionerBaseUrl,
     securityToken: securityToken,
+    spotBid: bid.price,
+    // Bug 1462768 - pass in hardcoded value since aws-provisioner-v1
+    // won't support running in any cluster other than this one
+    taskclusterRootUrl: 'https://taskcluster.net',
+    workerType: worker.workerType,
   };
 
   assert(!config.launchSpec.UserData, 'Dont specify UserData in launchSpec');


### PR DESCRIPTION
Hey John! I wasn't quite sure how to test this change, so it comes with the disclaimer it is in untested.

I think this shouldn't break any staging environment you might be using so long as you don't have bleeding-edge workers connected to it that use `taskclusterRootUrl` - but that might be a gotcha if you do want to do that - so just a warning!

Let me know if you'd like me to implement it differently.

Many thanks!