### PR TITLE
Increase identifier lengths from 22 to 38

### DIFF
--- a/lib/api-v1.js
+++ b/lib/api-v1.js
@@ -8,7 +8,7 @@ let url = require('url');
 let assert = require('assert');
 
 let SLUGID_PATTERN = /^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/;
-let GENERIC_ID_PATTERN = /^[a-zA-Z0-9-_]{1,22}$/;
+let GENERIC_ID_PATTERN = /^[a-zA-Z0-9-_]{1,38}$/;
 let EC2_INSTANCE_ID_PATTERN = /^i-[a-fA-F0-9]{8}$/;
 
 /**
@@ -352,7 +352,7 @@ api.declare({
     'compared against this value to see if changes have been made',
     'If the worker type definition has not been changed, the date',
     'should be identical as it is the same stored value.',
-    
+
   ].join('\n'),
 }, async function(req, res) {
   let workerType = req.params.workerType;

--- a/lib/exchanges.js
+++ b/lib/exchanges.js
@@ -27,7 +27,7 @@ let commonRoutingKey = [
     name: 'workerType',
     summary: 'WorkerType that this message concerns.',
     required: true,
-    maxSize: 22,
+    maxSize: 38,
   }, {
     name: 'reserved',
     summary: 'Space reserved for future routing-key entries, you ' +

--- a/schemas/constants.js
+++ b/schemas/constants.js
@@ -9,5 +9,13 @@
  */
 module.exports = {
   // Slugid pattern, for when-ever that is useful
-  "slugid-pattern":  "^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$"
+  "slugid-pattern":  "^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$",
+  // Identifier pattern, min and max length, these limitations are applied to
+  // all common identifiers. It's not personal, it's just that without these
+  // limitation, the identifiers won't be useful as routing keys in RabbitMQ
+  // topic exchanges. Specifically, the length limitation and the fact that
+  // identifiers can't contain dots `.` is critical.
+  "identifier-pattern":     "^([a-zA-Z0-9-_]*)$",
+  "identifier-min-length":  1,
+  "identifier-max-length":  38
 };

--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -1,0 +1,4 @@
+identifier-pattern:     "^([a-zA-Z0-9-_]*)$"
+identifier-min-length:  1
+identifier-max-length:  38
+slugid-pattern:  "^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$"

--- a/schemas/create-secret-request.yml
+++ b/schemas/create-secret-request.yml
@@ -6,6 +6,9 @@ type:                       object
 properties:
   workerType:
     type: string
+    minLength:    {$const: identifier-min-length}
+    maxLength:    {$const: identifier-max-length}
+    pattern:      {$const: identifier-pattern}
     description: |
       A string describing what the secret will be used for
   secrets:

--- a/schemas/get-worker-type-last-modified.yml
+++ b/schemas/get-worker-type-last-modified.yml
@@ -8,7 +8,9 @@ properties:
     type: string
     description: |
       The ID of the workerType
-    pattern: ^[A-Za-z0-9+/=_-]{1,22}$
+    minLength:    {$const: identifier-min-length}
+    maxLength:    {$const: identifier-max-length}
+    pattern:      {$const: identifier-pattern}
   lastModified:
     type: string
     format: date-time

--- a/schemas/get-worker-type-response.yml
+++ b/schemas/get-worker-type-response.yml
@@ -8,7 +8,9 @@ properties:
     type: string
     description: |
       The ID of the workerType
-    pattern: ^[A-Za-z0-9+/=_-]{1,22}$
+    minLength:    {$const: identifier-min-length}
+    maxLength:    {$const: identifier-max-length}
+    pattern:      {$const: identifier-pattern}
   launchSpec:
     type: object
     description: |
@@ -31,7 +33,7 @@ properties:
       UserData entries which are used in all regions and all instance types
   scopes:
     type: array
-    items: 
+    items:
       type: string
       pattern: "^[\x20-\x7e]*$"
     description: |

--- a/schemas/state-definition.yml
+++ b/schemas/state-definition.yml
@@ -6,7 +6,10 @@
     "workerType": {
       "title": "Worker Type",
       "description": "Worker type name\n",
-      "type": "string"
+      "type": "string",
+      "minLength":    {"$const": "identifier-min-length"},
+      "maxLength":    {"$const": "identifier-max-length"},
+      "pattern":      {"$const": "identifier-pattern"}
     },
     "instances": {
       "title": "Instances",

--- a/schemas/worker-type-message.yml
+++ b/schemas/worker-type-message.yml
@@ -7,6 +7,9 @@ properties:
     description: |
       Name of the worker type which was created
     type: string
+    minLength:    {$const: identifier-min-length}
+    maxLength:    {$const: identifier-max-length}
+    pattern:      {$const: identifier-pattern}
   version:
     type: number
 additionalProperties: false

--- a/schemas/worker-type-summary.yml
+++ b/schemas/worker-type-summary.yml
@@ -7,6 +7,9 @@ properties:
   workerType:
     title: Worker type name
     type: string
+    minLength:    {$const: identifier-min-length}
+    maxLength:    {$const: identifier-max-length}
+    pattern:      {$const: identifier-pattern}
   minCapacity:
     title: Minimum capacity of the workerType
     type: integer

--- a/test/badworkertype_test.js
+++ b/test/badworkertype_test.js
@@ -47,7 +47,7 @@ suite('Bad WorkerType definitions', () => {
 
   test('Should cause failure when creating', async () => {
     try {
-      await client.createWorkerType('createBadInput', {
+      await client.createWorkerType('sample-workerType-name-extended-extended', {
         bad: 'input',
       });
       throw new Error('Expected and error');


### PR DESCRIPTION
So i started working on this and made some changes but I'm able to run tests. This is the error I'm getting:- 

```
yarn run v1.12.3
$ yarn run lint && yarn run unittest
$ eslint lib/*.js test/*.js --fix
$ NODE_ENV=test node --stack-trace-limit=50 ./node_modules/mocha/bin/_mocha test/*_test.js


  1) "before all" hook
  2) "after all" hook

  0 passing (334ms)
  2 failing

  1)  "before all" hook:

      AssertionError [ERR_ASSERTION]: Must provide a namespace.
      + expected - actual

      -false
      +true
      
      at Exchanges._callee7$ (node_modules/pulse-publisher/src/exchanges.js:523:3)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:62:40)
      at Generator.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:296:22)
      at Generator.prototype.(anonymous function) [as next] (node_modules/regenerator-runtime/runtime.js:114:21)
      at step (node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
      at node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
      at new Promise (<anonymous>)
      at new F (node_modules/core-js/library/modules/_export.js:35:28)
      at Exchanges.<anonymous> (node_modules/babel-runtime/helpers/asyncToGenerator.js:14:12)
      at Exchanges.connect (node_modules/pulse-publisher/src/exchanges.js:515:1)
      at Exchanges.setup (node_modules/pulse-publisher/src/exchanges.js:712:22)
      at setup (lib/main.js:148:39)
      at node_modules/taskcluster-lib-loader/src/loader.js:215:28
      at tryCallOne (node_modules/promise/lib/core.js:37:12)
      at node_modules/promise/lib/core.js:123:15
      at flush (node_modules/asap/raw.js:50:29)
      at _combinedTickCallback (internal/process/next_tick.js:132:7)
      at process._tickDomainCallback (internal/process/next_tick.js:219:9)

  2)  "after all" hook:
     TypeError: Cannot read property 'terminate' of undefined
      at Context.mocha.after (test/helper.js:23:16)
```


Also, I had to add a `constants.yml` because it was not reading from `constants.js` 