### PR TITLE
Bug 1534667 - stop using signalfx, sentry

### DIFF
--- a/lib/api-v1.js
+++ b/lib/api-v1.js
@@ -506,7 +506,7 @@ api.declare({
   let input = req.body;
   let token = req.params.token;
 
-  await req.authorize({workerType: workerType});
+  await req.authorize({workerType: input.workerType});
 
   let secret;
   try {

--- a/lib/main.js
+++ b/lib/main.js
@@ -45,8 +45,11 @@ let load = loader({
     requires: ['process', 'profile', 'cfg'],
     setup: ({process, profile, cfg}) => libMonitor({
       project: cfg.monitoring.project,
-      enable: cfg.monitoring.enable,
-      credentials: cfg.taskcluster.credentials,
+
+      // Bug 1534667: disable monitoring, as auth service will no longer
+      // make signalfx, sentry tokens available
+      enable: false,
+
       mock: cfg.monitoring.mock,
       process,
     }),


### PR DESCRIPTION
I'll test this in staging -- at worst it will crash on startup, so that should be easy to spot :)