### PR TITLE
Bug 1375197 - prohibit secrets in worker-type configs

### DIFF
--- a/schemas/availability-zone-configuration.yml
+++ b/schemas/availability-zone-configuration.yml
@@ -17,8 +17,10 @@ properties:
       LaunchSpecification entries unique to this AZ
   secrets:
     type: object
+    # this object must be empty
+    additionalProperties: false
     description: |
-      Static Secrets unique to this AZ
+      Secrets properties are deprecated, and only an empty object is allowed. Secrets have been migrated to the secrets service, with secret name `worker-type:aws-provisioner-v1/<workerType>`.
     default: {}
   userData:
     type: object

--- a/schemas/create-worker-type-request.yml
+++ b/schemas/create-worker-type-request.yml
@@ -18,8 +18,10 @@ properties:
       A string which identifies the owner of this worker type
   secrets:
     type: object
+    # this object must be empty
+    additionalProperties: false
     description: |
-      Static secrets entries which are used in all regions and all instance types
+      Secrets properties are deprecated, and only an empty object is allowed. Secrets have been migrated to the secrets service, with secret name `worker-type:aws-provisioner-v1/<workerType>`.
   userData:
     type: object
     description: |

--- a/schemas/get-worker-type-response.yml
+++ b/schemas/get-worker-type-response.yml
@@ -25,8 +25,10 @@ properties:
       A string which identifies the owner of this worker type
   secrets:
     type: object
+    # this object must be empty
+    additionalProperties: false
     description: |
-      Static secrets entries which are used in all regions and all instance types
+      Secrets properties are deprecated, and only an empty object is allowed. Secrets have been migrated to the secrets service, with secret name `worker-type:aws-provisioner-v1/<workerType>`.
   userData:
     type: object
     description: |

--- a/schemas/instance-type-configuration.yml
+++ b/schemas/instance-type-configuration.yml
@@ -25,8 +25,10 @@ properties:
       LaunchSpecification entries unique to this InstanceType
   secrets:
     type: object
+    # this object must be empty
+    additionalProperties: false
     description: |
-      Static Secrets unique to this InstanceType
+      Secrets properties are deprecated, and only an empty object is allowed. Secrets have been migrated to the secrets service, with secret name `worker-type:aws-provisioner-v1/<workerType>`.
   userData:
     type: object
     description: |

--- a/schemas/region-configuration.yml
+++ b/schemas/region-configuration.yml
@@ -16,8 +16,10 @@ properties:
   launchSpec: {$ref: "http://schemas.taskcluster.net/aws-provisioner/v1/region-launch-spec.json#"}
   secrets:
     type: object
+    # this object must be empty
+    additionalProperties: false
     description: |
-      Static Secrets unique to this Region
+      Secrets properties are deprecated, and only an empty object is allowed. Secrets have been migrated to the secrets service, with secret name `worker-type:aws-provisioner-v1/<workerType>`.
   userData:
     type: object
     description: |


### PR DESCRIPTION
The schemas cover both input (create, update workertype) and output (get workertype).  I verified again that there are no secrets at present, so once this is in place we'll be "locked" in that situation.

John suggested long ago that removing fields from the workerType could cause issues.  I'm not really sure what those issues would be, but this PR is better-safe-than-sorry with a deprecated service.